### PR TITLE
[IMP] improve naming and refactor functions

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -18,6 +18,14 @@ use std::rc::Rc;
 use crate::cpu::registers::{R8, R16, Registers};
 use crate::mmu::Mmu;
 
+const BLOCK_MASK: u8 = 0b11000000;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum StepStatus {
+    Continue,
+    Halted,
+}
+
 pub struct Cpu {
     pub registers: Registers,
     pub pc: u16,
@@ -42,8 +50,7 @@ impl Cpu {
     }
 
     fn execute_instruction(&mut self, instruction: u8) {
-        let block_mask = 0b11000000;
-        let block = (instruction & block_mask) >> 6;
+        let block = (instruction & BLOCK_MASK) >> 6;
         match block {
             0b00 => block0::execute_instruction_block0(self, instruction),
             0b01 => block1::execute_instruction_block1(self, instruction),
@@ -56,14 +63,14 @@ impl Cpu {
         }
     }
 
-    pub fn step(&mut self) {
+    fn handle_halt_state(&mut self) -> StepStatus {
         if self.halted {
             let bus = self.bus.borrow();
             let iflag = bus.read_interrupt_flag();
             let ienable = bus.read_interrupt_enable();
 
             if ienable & iflag == 0 {
-                return;
+                return StepStatus::Halted;
             }
 
             self.halted = false;
@@ -72,6 +79,10 @@ impl Cpu {
                 self.halt_bug = true;
             }
         }
+        StepStatus::Continue
+    }
+
+    fn handle_ime_state(&mut self) -> StepStatus {
         if self.ime {
             let mut bus = self.bus.borrow_mut();
             if let Some(interrupt) = bus.interrupts_next_request() {
@@ -89,22 +100,42 @@ impl Cpu {
                 bus.write_byte(sp2, (ret_addr & 0xFF) as u8);
 
                 self.pc = interrupt.vector();
-                return;
+                StepStatus::Halted
+            } else {
+                StepStatus::Continue
             }
+        } else {
+            StepStatus::Continue
         }
-        let instruction_byte = self.bus.borrow().read_byte(self.pc);
-        // println!("pc: 0x{:02X}", self.pc);
-        // println!("opcode: 0x{:02X}", instruction_byte);
-        self.execute_instruction(instruction_byte);
+    }
 
+    fn handle_halt_bug(&mut self) {
         if self.halt_bug {
             self.pc = self.pc.wrapping_sub(1);
             self.halt_bug = false;
         }
+    }
+
+    fn handle_ime_delay(&mut self) {
         if self.ime_delay {
             self.ime = true;
             self.ime_delay = false;
         }
+    }
+
+    pub fn step(&mut self) {
+        if self.handle_halt_state() == StepStatus::Halted {
+            return;
+        }
+        if self.handle_ime_state() == StepStatus::Halted {
+            return;
+        }
+
+        let instruction_byte = self.bus.borrow().read_byte(self.pc);
+        self.execute_instruction(instruction_byte);
+
+        self.handle_halt_bug();
+        self.handle_ime_delay();
 
         // println!("{}", self);
     }

--- a/src/cpu/block0.rs
+++ b/src/cpu/block0.rs
@@ -7,6 +7,9 @@ use crate::cpu::registers::{R8, R16, R16Mem};
 use crate::cpu::utils;
 
 const COND_MASK: u8 = 0b00011000;
+const LAST_3_BITS_MASK: u8 = 0b00000111;
+const LAST_4_BITS_MASK: u8 = 0b00001111;
+const FIRST_3_BITS_MASK: u8 = 0b11100000;
 
 const INSTRUCTIONS_BLOCK0: [u8; 22] = [
     0b00000000, //nop
@@ -34,10 +37,6 @@ const INSTRUCTIONS_BLOCK0: [u8; 22] = [
 ];
 
 fn get_instruction_block0(instruction: u8) -> u8 {
-    let mask_last_3_bits = 0b00000111;
-    let mask_last_4_bits = 0b00001111;
-    let mask_first_3_bits = 0b11100000;
-
     if INSTRUCTIONS_BLOCK0.contains(&instruction) {
         return instruction;
     }
@@ -45,7 +44,7 @@ fn get_instruction_block0(instruction: u8) -> u8 {
     let mut match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK0
         .iter()
         .cloned()
-        .filter(|&opcode| (instruction & mask_last_3_bits) == (opcode & mask_last_3_bits))
+        .filter(|&opcode| (instruction & LAST_3_BITS_MASK) == (opcode & LAST_3_BITS_MASK))
         .collect();
 
     if match_opcode.len() == 1 {
@@ -54,10 +53,10 @@ fn get_instruction_block0(instruction: u8) -> u8 {
 
     let mut match_opcode_cpy = match_opcode.clone();
 
-    match_opcode.retain(|&opcode| (instruction & mask_last_4_bits) == (opcode & mask_last_4_bits));
+    match_opcode.retain(|&opcode| (instruction & LAST_4_BITS_MASK) == (opcode & LAST_4_BITS_MASK));
     if match_opcode.len() > 1 {
         match_opcode_cpy
-            .retain(|&opcode| (instruction & mask_first_3_bits) == (opcode & mask_first_3_bits));
+            .retain(|&opcode| (instruction & FIRST_3_BITS_MASK) == (opcode & FIRST_3_BITS_MASK));
         if match_opcode_cpy.len() == 1 {
             return match_opcode_cpy[0];
         }
@@ -112,7 +111,7 @@ fn load_r16_imm16(cpu: &mut Cpu, instruction: u8) {
     let r16 = R16::from((instruction & utils::R16_MASK) >> 4);
 
     cpu.registers.set_r16_value(r16, imm16);
-    cpu.pc += 3;
+    cpu.pc = cpu.pc.wrapping_add(3);
 }
 
 fn load_r16mem_a(cpu: &mut Cpu, instruction: u8) {
@@ -124,7 +123,7 @@ fn load_r16mem_a(cpu: &mut Cpu, instruction: u8) {
     if r16_mem == R16Mem::HLincrement || r16_mem == R16Mem::HLdecrement {
         utils::modify_hl(cpu, r16_mem);
     }
-    cpu.pc += 1;
+    cpu.pc = cpu.pc.wrapping_add(1);
 }
 
 fn load_a_r16mem(cpu: &mut Cpu, instruction: u8) {
@@ -138,7 +137,7 @@ fn load_a_r16mem(cpu: &mut Cpu, instruction: u8) {
         utils::modify_hl(cpu, r16_mem);
     }
 
-    cpu.pc += 1;
+    cpu.pc = cpu.pc.wrapping_add(1);
 }
 
 fn load_mem_imm16_sp(cpu: &mut Cpu) {
@@ -187,7 +186,7 @@ fn inc_r8(cpu: &mut Cpu, instruction: u8) {
     cpu.registers.set_half_carry_flag((value & 0x0F) + 1 > 0x0F);
 
     cpu.set_r8_value(r8, new_value);
-    cpu.pc += 1;
+    cpu.pc = cpu.pc.wrapping_add(1);
 }
 
 fn dec_r8(cpu: &mut Cpu, instruction: u8) {

--- a/src/cpu/block2.rs
+++ b/src/cpu/block2.rs
@@ -8,6 +8,7 @@ use crate::cpu::utils;
 const R16_MASK: u8 = 0b00110000;
 const R8_MASK: u8 = 0b00111000;
 const COND_MASK: u8 = 0b00011000;
+const MIDDLE_3_BITS_MASK: u8 = 0b00111000;
 
 const INSTRUCTIONS_BLOCK2: [u8; 8] = [
     0b10000000, //add a, r8
@@ -21,12 +22,10 @@ const INSTRUCTIONS_BLOCK2: [u8; 8] = [
 ];
 
 fn get_instruction_block2(instruction: u8) -> u8 {
-    let block2_mask: u8 = 0b00111000;
-
     let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK2
         .iter()
         .cloned()
-        .filter(|&opcode| (instruction & block2_mask) == (opcode & block2_mask))
+        .filter(|&opcode| (instruction & MIDDLE_3_BITS_MASK) == (opcode & MIDDLE_3_BITS_MASK))
         .collect();
 
     if match_opcode.len() == 1 {
@@ -48,7 +47,6 @@ pub fn execute_instruction_block2(cpu: &mut Cpu, instruction: u8) {
         0b10101000 => xor_a_r8(cpu, instruction),
         0b10110000 => or_a_r8(cpu, instruction),
         0b10111000 => cp_a_r8(cpu, instruction),
-        // implement halt
         _ => cpu.pc = cpu.pc.wrapping_add(1),
     }
 }

--- a/src/cpu/block_prefix.rs
+++ b/src/cpu/block_prefix.rs
@@ -8,6 +8,8 @@ use crate::cpu::utils;
 
 const R8_MASK: u8 = 0b00000111;
 const B3_MASK: u8 = 0b00111000;
+const MIDDLE_3_BITS_MASK: u8 = 0b00111000;
+const FIRST_2_BITS_MASK: u8 = 0b11000000;
 
 const RST_VEC: [u8; 8] = [0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38];
 
@@ -28,18 +30,12 @@ const INSTRUCTIONS_BLOCK_PREFIX2: [u8; 3] = [
     0b11000000, //set b3, r8
 ];
 
-/// GET the instruction based on the opcode and returns the corresponding instruction.
 fn get_instruction_block_prefix(instruction: u8) -> u8 {
-    // Masques pour identifier les groupes d'instructions
-    let block_prefix_mask1 = 0b00111000; // Bits 3 à 5
-    let block_prefix_mask2 = 0b11000000; // Bits 6 et 7
-
-    // Vérifier si l'instruction appartient au groupe PREFIX2 (BIT, RES, SET)
-    if (instruction & block_prefix_mask2) != 0 {
+    if (instruction & FIRST_2_BITS_MASK) != 0 {
         let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK_PREFIX2
             .iter()
             .cloned()
-            .filter(|&opcode| (instruction & block_prefix_mask2) == (opcode & block_prefix_mask2))
+            .filter(|&opcode| (instruction & FIRST_2_BITS_MASK) == (opcode & FIRST_2_BITS_MASK))
             .collect();
 
         if match_opcode.len() == 1 {
@@ -47,18 +43,16 @@ fn get_instruction_block_prefix(instruction: u8) -> u8 {
         }
     }
 
-    // Sinon, vérifier si l'instruction appartient au groupe PREFIX1 (RLC, RRC, etc.)
     let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK_PREFIX1
         .iter()
         .cloned()
-        .filter(|&opcode| (instruction & block_prefix_mask1) == (opcode & block_prefix_mask1))
+        .filter(|&opcode| (instruction & MIDDLE_3_BITS_MASK) == (opcode & MIDDLE_3_BITS_MASK))
         .collect();
 
     if match_opcode.len() == 1 {
         return match_opcode[0];
     }
 
-    // Si aucune correspondance unique n'est trouvée
     panic!("No unique instruction found for opcode: {instruction:#04x}");
 }
 

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -8,6 +8,8 @@ use crate::cpu::Cpu;
 use crate::mmu::Mmu;
 use crate::ppu::Ppu;
 
+const FRAME_CYCLES: u32 = 70224;
+
 #[derive(Default)]
 pub struct GameBoy {
     pub cpu: Cpu,
@@ -27,7 +29,7 @@ impl GameBoy {
     pub fn run_frame(&mut self) -> Vec<u8> {
         let mut cycles_this_frame = 0;
 
-        while cycles_this_frame < 70224 {
+        while cycles_this_frame < FRAME_CYCLES {
             self.bus.borrow_mut().tick_timers();
             self.cpu.step();
             cycles_this_frame += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         args.pop()
             .expect("Expected a ROM name as the second argument")
     } else {
-        "roms/cpu_instrs.gb".to_string()
+        "roms/individual/02-interrupts.gb".to_string()
     };
 
     let rom_data: Vec<u8> = read_rom(rom_path);

--- a/src/mmu/interrupt.rs
+++ b/src/mmu/interrupt.rs
@@ -38,7 +38,7 @@ impl InterruptController {
         self.ienable & 0b00011111
     }
 
-    pub fn write_ie(&mut self, val: u8) {
+    pub fn write_interrupt_enable(&mut self, val: u8) {
         self.ienable = val & 0b00011111;
     }
 
@@ -46,7 +46,7 @@ impl InterruptController {
         self.iflag | 0b11100000
     }
 
-    pub fn write_if(&mut self, val: u8) {
+    pub fn write_interrupt_flag(&mut self, val: u8) {
         self.iflag = val & 0b00011111;
     }
 
@@ -88,22 +88,22 @@ mod tests {
     }
 
     #[test]
-    fn test_read_write_ie() {
+    fn test_read_write_interrupt_enable() {
         let mut ic = InterruptController::new();
         assert_eq!(ic.read_interrupt_enable(), 0);
-        ic.write_ie(0b1111_1111);
+        ic.write_interrupt_enable(0b1111_1111);
         assert_eq!(ic.read_interrupt_enable(), 0b0001_1111);
-        ic.write_ie(0b0000_0101);
+        ic.write_interrupt_enable(0b0000_0101);
         assert_eq!(ic.read_interrupt_enable(), 0b0000_0101);
     }
 
     #[test]
-    fn test_read_write_if() {
+    fn test_read_write_interrupt_flag() {
         let mut ic = InterruptController::new();
         assert_eq!(ic.read_interrupt_flag(), 0b1110_0000);
-        ic.write_if(0b1010_1010);
+        ic.write_interrupt_flag(0b1010_1010);
         assert_eq!(ic.read_interrupt_flag(), 0b1110_1010);
-        ic.write_if(0);
+        ic.write_interrupt_flag(0);
         assert_eq!(ic.read_interrupt_flag(), 0b1110_0000);
     }
 
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn test_next_request_priority_and_masking() {
         let mut ic = InterruptController::new();
-        ic.write_ie(
+        ic.write_interrupt_enable(
             (Interrupt::VBlank as u8) | (Interrupt::Timer as u8) | (Interrupt::Joypad as u8),
         );
         for &int in &[

--- a/src/mmu/mbc.rs
+++ b/src/mmu/mbc.rs
@@ -1,5 +1,7 @@
 use std::cmp::min;
 
+const ROM_BANK_SIZE: usize = 0x4000;
+
 #[derive(Clone)]
 pub struct Mbc {
     banks: Vec<[u8; 0x4000]>,
@@ -12,17 +14,17 @@ impl Mbc {
         let mut offset = 0;
 
         while offset < rom_image.len() {
-            let mut bank = [0u8; 0x4000];
+            let mut bank = [0u8; ROM_BANK_SIZE];
 
-            let end = min(offset + 0x4000, rom_image.len());
+            let end = min(offset + ROM_BANK_SIZE, rom_image.len());
             let len = end - offset;
 
             bank[..len].copy_from_slice(&rom_image[offset..end]);
             banks.push(bank);
-            offset += 0x4000;
+            offset += ROM_BANK_SIZE;
         }
         if banks.len() < 2 {
-            banks.resize(2, [0u8; 0x4000]);
+            banks.resize(2, [0u8; ROM_BANK_SIZE]);
         }
 
         Mbc { banks, current: 1 }
@@ -31,10 +33,10 @@ impl Mbc {
     pub fn read(&self, addr: u16) -> u8 {
         let i = addr as usize;
 
-        if i < 0x4000 {
+        if i < ROM_BANK_SIZE {
             self.banks[0][i]
         } else {
-            let off = i - 0x4000;
+            let off = i - ROM_BANK_SIZE;
 
             self.banks[self.current][off]
         }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -4,13 +4,24 @@
 pub mod lcd_control;
 pub mod lcd_status;
 
+use crate::mmu::MemoryRegion;
 use crate::mmu::Mmu;
 use crate::ppu::lcd_control::LcdControl;
 use crate::ppu::lcd_status::LcdStatus;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-const VRAM_START: u16 = 0x8000; // Start of VRAM
+const VRAM: MemoryRegion = MemoryRegion::Vram; // Start of VRAM
+const LY_ADDR: u16 = 0xFF44; // LCDC Y-Coordinate
+const LYC_ADDR: u16 = 0xFF45; // LY Compare
+const STAT_ADDR: u16 = 0xFF41; // LCDC Status
+const SCX_ADDR: u16 = 0xFF43; // Scroll X
+const SCY_ADDR: u16 = 0xFF42; // Scroll Y
+const WY_ADDR: u16 = 0xFF4A; // Window Y Position
+const WX_ADDR: u16 = 0xFF4B; // Window X Position
+const LCD_CONTROL_ADDR: u16 = 0xFF40; // LCDC Control
+const TILE_DATA_0: std::ops::Range<u16> = 0x8800..0x9800; // Tile Data Area 0
+const TILE_DATA_1: std::ops::Range<u16> = 0x8000..0x9000; // Tile Data Area 1
 
 #[derive(Default)]
 pub struct Ppu {
@@ -42,7 +53,7 @@ impl Ppu {
 
     pub fn display_vram(&self) {
         for i in 0..0x2000 {
-            let byte = self.bus.borrow().read_byte(VRAM_START + i as u16);
+            let byte = self.bus.borrow().read_byte(VRAM.to_address() + i as u16);
             print!("{byte:02X} ");
             if (i + 1) % 16 == 0 {
                 println!();
@@ -53,8 +64,7 @@ impl Ppu {
     pub fn display_tiles_data(&self) {
         println!("Tile Data Area:");
         for tile_index in 0..384 {
-            // 384 tiles, each 16 bytes
-            let tile_address = VRAM_START + (tile_index as u16 * 16);
+            let tile_address = VRAM.to_address() + (tile_index as u16 * 16);
             print!("{tile_address:04x} Tile {tile_index:03}: ");
             for byte_index in 0..16 {
                 let byte = self
@@ -104,12 +114,12 @@ impl Ppu {
         tile_data
     }
 
-    pub fn display_all_tiles(&self) -> Vec<u8> {
+    pub fn render_all_tiles(&self) -> Vec<u8> {
         let mut frame = vec![0; 160 * 144 * 3];
         for y in 0..144 {
             for x in 0..160 {
                 let tile_index = (y / 8) * 20 + (x / 8);
-                let base_address = VRAM_START + (tile_index as u16 * 16);
+                let base_address = VRAM.to_address() + (tile_index as u16 * 16);
                 let tile_data = self.read_tile_data(base_address);
                 let color = self.get_pixel_color(tile_data, x, y);
                 let offset = (y * 160 + x) * 3;
@@ -127,14 +137,14 @@ impl Ppu {
             for x in 0..160 {
                 let y_tile = y / 8;
                 let x_tile = x / 8;
-                let tilemap_base: std::ops::Range<u16> = self.lcd_control.get_bg_tile_map();
+                let tilemap_base: std::ops::Range<u16> = self.lcd_control.bg_tile_map_area();
 
                 let offset = (y_tile * 32 + x_tile) as u16;
                 let tile_number = self.bus.borrow().read_byte(tilemap_base.start + offset);
-                let tile_address = if self.lcd_control.get_bg_window_tiles() {
-                    0x8000 + (tile_number as u16) * 16
-                } else {
-                    0x8080 + ((tile_number as i8) as u16 + 128) * 16
+                let tile_address = match self.lcd_control.bg_window_tile_data_area() {
+                    TILE_DATA_1 => 0x8000 + (tile_number as u16) * 16,
+                    TILE_DATA_0 => 0x8800 + ((tile_number as i8 as i16) as u16) * 16,
+                    _ => unreachable!(),
                 };
 
                 let tile_data = self.read_tile_data(tile_address);
@@ -149,12 +159,13 @@ impl Ppu {
     }
 
     pub fn update_registers(&mut self) {
-        self.ly = self.bus.borrow().read_byte(0xFF44);
-        self.lyc = self.bus.borrow().read_byte(0xFF45);
-        self.scy = self.bus.borrow().read_byte(0xFF42);
-        self.scx = self.bus.borrow().read_byte(0xFF43);
-        self.wy = self.bus.borrow().read_byte(0xFF4A);
-        self.wx = self.bus.borrow().read_byte(0xFF4B);
-        self.lcd_control.update(self.bus.borrow().read_byte(0xFF40));
+        self.ly = self.bus.borrow().read_byte(LY_ADDR);
+        self.lyc = self.bus.borrow().read_byte(LYC_ADDR);
+        self.scy = self.bus.borrow().read_byte(SCY_ADDR);
+        self.scx = self.bus.borrow().read_byte(SCX_ADDR);
+        self.wy = self.bus.borrow().read_byte(WY_ADDR);
+        self.wx = self.bus.borrow().read_byte(WX_ADDR);
+        self.lcd_control
+            .update_from_byte(self.bus.borrow().read_byte(LCD_CONTROL_ADDR));
     }
 }

--- a/src/ppu/lcd_control.rs
+++ b/src/ppu/lcd_control.rs
@@ -3,106 +3,118 @@
 
 use std::ops::Range;
 
+pub const TILE_MAP_0: Range<u16> = 0x9800..0x9C00;
+pub const TILE_MAP_1: Range<u16> = 0x9C00..0xA000;
+
+pub const TILE_DATA_0: Range<u16> = 0x8800..0x9800;
+pub const TILE_DATA_1: Range<u16> = 0x8000..0x9000;
+
+const PPU_ENABLE_MASK: u8 = 0b1000_0000;
+const WINDOW_TILE_MAP_MASK: u8 = 0b0100_0000;
+const WINDOW_ENABLE_MASK: u8 = 0b0010_0000;
+const BG_WINDOW_TILE_DATA_MASK: u8 = 0b0001_0000;
+const BG_TILE_MAP_MASK: u8 = 0b0000_1000;
+const OBJ_SIZE_MASK: u8 = 0b0000_0100;
+const OBJ_ENABLE_MASK: u8 = 0b0000_0010;
+const BG_WINDOW_ENABLE_MASK: u8 = 0b0000_0001;
+
 #[derive(Default)]
 pub struct LcdControl {
     ppu_enable: bool,
     window_tile_map_area: bool,
     window_enable: bool,
-    bg_window_tiles: bool,
-    bg_tile_map: bool,
-    obj_size: bool,
+    bg_window_tile_data_area: bool,
+    bg_tile_map_area: bool,
+    obj_size_8x16: bool,
     obj_enable: bool,
     bg_window_enable: bool,
 }
 
 impl LcdControl {
-    pub fn set_ppu_enable(&mut self, enable: bool) {
+    pub fn enable_ppu(&mut self, enable: bool) {
         self.ppu_enable = enable;
     }
 
-    pub fn set_window_tile_map_area(&mut self, area: bool) {
-        self.window_tile_map_area = area;
+    pub fn select_window_tile_map(&mut self, use_map1: bool) {
+        self.window_tile_map_area = use_map1;
     }
 
-    pub fn set_window_enable(&mut self, enable: bool) {
+    pub fn enable_window(&mut self, enable: bool) {
         self.window_enable = enable;
     }
 
-    pub fn set_bg_window_tiles(&mut self, tiles: bool) {
-        self.bg_window_tiles = tiles;
+    pub fn select_bg_window_tile_data(&mut self, use_data1: bool) {
+        self.bg_window_tile_data_area = use_data1;
     }
 
-    pub fn set_bg_tile_map(&mut self, map: bool) {
-        self.bg_tile_map = map;
+    pub fn select_bg_tile_map(&mut self, use_map1: bool) {
+        self.bg_tile_map_area = use_map1;
     }
 
-    pub fn set_obj_size(&mut self, size: bool) {
-        self.obj_size = size;
+    pub fn set_obj_size_8x16(&mut self, is_8x16: bool) {
+        self.obj_size_8x16 = is_8x16;
     }
 
-    pub fn set_obj_enable(&mut self, enable: bool) {
+    pub fn enable_obj(&mut self, enable: bool) {
         self.obj_enable = enable;
     }
 
-    pub fn set_bg_window_enable(&mut self, enable: bool) {
+    pub fn enable_bg_window(&mut self, enable: bool) {
         self.bg_window_enable = enable;
     }
 
-    pub fn get_ppu_enable(&self) -> bool {
+    pub fn is_ppu_enabled(&self) -> bool {
         self.ppu_enable
     }
 
-    pub fn get_window_tile_map_area(&self) -> Range<u16> {
+    pub fn window_tile_map_area(&self) -> Range<u16> {
         if self.window_tile_map_area {
-            0x9C00..0x9F00
+            TILE_MAP_1
         } else {
-            0x9800..0x9BFF
+            TILE_MAP_0
         }
     }
 
-    pub fn get_window_enable(&self) -> bool {
+    pub fn is_window_enabled(&self) -> bool {
         self.window_enable
     }
 
-    pub fn get_bg_window_tiles(&self) -> bool {
-        self.bg_window_tiles
-    }
-
-    pub fn get_bg_window_tiles_area(&self) -> Range<u16> {
-        if self.bg_window_tiles {
-            0x8000..0x8FFF
+    pub fn bg_window_tile_data_area(&self) -> Range<u16> {
+        if self.bg_window_tile_data_area {
+            TILE_DATA_1
         } else {
-            0x8800..0x97FF
+            TILE_DATA_0
         }
     }
 
-    pub fn get_bg_tile_map(&self) -> Range<u16> {
-        if self.bg_tile_map {
-            0x9c00..0x9FFF
+    pub fn bg_tile_map_area(&self) -> Range<u16> {
+        if self.bg_tile_map_area {
+            TILE_MAP_1
         } else {
-            0x9800..0x9BFF
+            TILE_MAP_0
         }
     }
 
-    pub fn get_obj_size(&self) -> bool {
-        self.obj_size
+    pub fn is_obj_size_8x16(&self) -> bool {
+        self.obj_size_8x16
     }
 
-    pub fn get_obj_enable(&self) -> bool {
+    pub fn is_obj_enabled(&self) -> bool {
         self.obj_enable
     }
-    pub fn get_bg_window_enable(&self) -> bool {
+
+    pub fn is_bg_window_enabled(&self) -> bool {
         self.bg_window_enable
     }
 
-    pub fn update(&mut self, value: u8) {
-        self.ppu_enable = value & 0b1000_0000 != 0;
-        self.window_tile_map_area = value & 0b0100_0000 != 0;
-        self.window_enable = value & 0b0010_0000 != 0;
-        self.bg_window_tiles = value & 0b0001_0000 != 0;
-        self.bg_tile_map = value & 0b0000_1000 != 0;
-        self.obj_size = value & 0b0000_0100 != 0;
-        self.obj_enable = value & 0b0000_0010 != 0;
-        self.bg_window_enable = value & 0b0000_0001 != 0;
+    pub fn update_from_byte(&mut self, value: u8) {
+        self.ppu_enable = value & PPU_ENABLE_MASK != 0;
+        self.window_tile_map_area = value & WINDOW_TILE_MAP_MASK != 0;
+        self.window_enable = value & WINDOW_ENABLE_MASK != 0;
+        self.bg_window_tile_data_area = value & BG_WINDOW_TILE_DATA_MASK != 0;
+        self.bg_tile_map_area = value & BG_TILE_MAP_MASK != 0;
+        self.obj_size_8x16 = value & OBJ_SIZE_MASK != 0;
+        self.obj_enable = value & OBJ_ENABLE_MASK != 0;
+        self.bg_window_enable = value & BG_WINDOW_ENABLE_MASK != 0;
     }
 }

--- a/src/ppu/lcd_status.rs
+++ b/src/ppu/lcd_status.rs
@@ -1,6 +1,15 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum PpuMode {
+    #[default]
+    HBlank = 0,
+    VBlank = 1,
+    OamSearch = 2,
+    PixelTransfer = 3,
+}
+
 #[derive(Default)]
 pub struct LcdStatus {
     lyc_int_select: bool,
@@ -8,7 +17,7 @@ pub struct LcdStatus {
     mode_1_int_select: bool,
     mode_0_int_select: bool,
     lyc_equals_ly: bool,
-    ppu_mode: u8, // 0: H-Blank, 1: V-Blank, 2: OAM Search, 3: Pixel Transfer
+    ppu_mode: PpuMode,
 }
 
 impl LcdStatus {
@@ -19,11 +28,11 @@ impl LcdStatus {
             mode_1_int_select: false,
             mode_0_int_select: false,
             lyc_equals_ly: false,
-            ppu_mode: 0, // Default to H-Blank
+            ppu_mode: PpuMode::HBlank,
         }
     }
 
-    pub fn update_ppu_mode(&mut self, mode: u8) {
+    pub fn update_ppu_mode(&mut self, mode: PpuMode) {
         self.ppu_mode = mode;
     }
 


### PR DESCRIPTION
This PR improves code readability and maintainability by:

    Replacing magic numbers with named constants

    Renaming variables with unclear or non-explicit names

    Splitting a too-long function into smaller, focused functions

Feel free to suggest or make any changes if you think improvements are needed.