### PR TITLE
[IMP] 24 - improve naming and refactor functions 

### DIFF
--- a/src/cpu/block2.rs
+++ b/src/cpu/block2.rs
@@ -8,6 +8,7 @@ use crate::cpu::utils;
 const R16_MASK: u8 = 0b00110000;
 const R8_MASK: u8 = 0b00111000;
 const COND_MASK: u8 = 0b00011000;
+const MIDDLE_3_BITS_MASK: u8 = 0b00111000;
 
 const INSTRUCTIONS_BLOCK2: [u8; 8] = [
     0b10000000, //add a, r8
@@ -21,12 +22,10 @@ const INSTRUCTIONS_BLOCK2: [u8; 8] = [
 ];
 
 fn get_instruction_block2(instruction: u8) -> u8 {
-    let block2_mask: u8 = 0b00111000;
-
     let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK2
         .iter()
         .cloned()
-        .filter(|&opcode| (instruction & block2_mask) == (opcode & block2_mask))
+        .filter(|&opcode| (instruction & MIDDLE_3_BITS_MASK) == (opcode & MIDDLE_3_BITS_MASK))
         .collect();
 
     if match_opcode.len() == 1 {
@@ -48,7 +47,6 @@ pub fn execute_instruction_block2(cpu: &mut Cpu, instruction: u8) -> u8 {
         0b10101000 => xor_a_r8(cpu, instruction),
         0b10110000 => or_a_r8(cpu, instruction),
         0b10111000 => cp_a_r8(cpu, instruction),
-        // implement halt
         _ => unreachable!(),
     }
 

--- a/src/cpu/block3.rs
+++ b/src/cpu/block3.rs
@@ -10,6 +10,8 @@ use crate::cpu::utils;
 const R16STK_MASK: u8 = 0b00110000;
 const TGT3_MASK: u8 = 0b00111000;
 const COND_MASK: u8 = 0b00011000;
+const FIRST_3_BITS_MASK: u8 = 0b11100000;
+const LAST_3_BITS_MASK: u8 = 0b00000111;
 
 const RST_VEC: [u8; 8] = [0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38];
 
@@ -72,9 +74,6 @@ fn check_stack_stk16_instruction(instruction: u8) -> u8 {
 }
 
 fn get_instruction_block3(instruction: u8) -> u8 {
-    let block3_mask = 0b00000111;
-    let cond_mask = 0b11100000;
-
     if INSTRUCTIONS_BLOCK3.contains(&instruction) || INSTRUCTION_INTERRUPT.contains(&instruction) {
         return instruction;
     }
@@ -87,7 +86,7 @@ fn get_instruction_block3(instruction: u8) -> u8 {
     let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK3
         .iter()
         .cloned()
-        .filter(|&opcode| (instruction & block3_mask) == (opcode & block3_mask))
+        .filter(|&opcode| (instruction & LAST_3_BITS_MASK) == (opcode & LAST_3_BITS_MASK))
         .collect();
 
     if match_opcode.len() == 1 {
@@ -96,7 +95,7 @@ fn get_instruction_block3(instruction: u8) -> u8 {
 
     let match_cond_opcode: Vec<u8> = match_opcode
         .into_iter()
-        .filter(|&opcode| (instruction & cond_mask) == (opcode & cond_mask))
+        .filter(|&opcode| (instruction & FIRST_3_BITS_MASK) == (opcode & FIRST_3_BITS_MASK))
         .collect();
 
     if match_cond_opcode.len() == 1 {
@@ -708,24 +707,6 @@ mod tests {
 
         assert_eq!(cpu.registers.get_sp(), 0x1234);
     }
-
-    // #[test]
-    // fn test_di() {
-    //     let mut cpu = Cpu::default();
-    //     cpu.registers.set_interrupts_enabled(true);
-    //     execute_instruction_block3(&mut cpu, 0xF3); // DI
-
-    //     assert!(!cpu.registers.get_interrupts_enabled());
-    // }
-
-    // #[test]
-    // fn test_ei() {
-    //     let mut cpu = Cpu::default();
-    //     cpu.registers.set_interrupts_enabled(false);
-    //     execute_instruction_block3(&mut cpu, 0xFB); // EI
-
-    //     assert!(cpu.registers.get_interrupts_enabled());
-    // }
 
     #[test]
     fn test_ldh_a_c() {

--- a/src/cpu/block_prefix.rs
+++ b/src/cpu/block_prefix.rs
@@ -8,6 +8,8 @@ use crate::cpu::utils;
 
 const R8_MASK: u8 = 0b00000111;
 const B3_MASK: u8 = 0b00111000;
+const MIDDLE_3_BITS_MASK: u8 = 0b00111000;
+const FIRST_2_BITS_MASK: u8 = 0b11000000;
 
 const RST_VEC: [u8; 8] = [0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38];
 
@@ -28,18 +30,12 @@ const INSTRUCTIONS_BLOCK_PREFIX2: [u8; 3] = [
     0b11000000, //set b3, r8
 ];
 
-/// GET the instruction based on the opcode and returns the corresponding instruction.
 fn get_instruction_block_prefix(instruction: u8) -> u8 {
-    // Masques pour identifier les groupes d'instructions
-    let block_prefix_mask1 = 0b00111000; // Bits 3 à 5
-    let block_prefix_mask2 = 0b11000000; // Bits 6 et 7
-
-    // Vérifier si l'instruction appartient au groupe PREFIX2 (BIT, RES, SET)
-    if (instruction & block_prefix_mask2) != 0 {
+    if (instruction & FIRST_2_BITS_MASK) != 0 {
         let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK_PREFIX2
             .iter()
             .cloned()
-            .filter(|&opcode| (instruction & block_prefix_mask2) == (opcode & block_prefix_mask2))
+            .filter(|&opcode| (instruction & FIRST_2_BITS_MASK) == (opcode & FIRST_2_BITS_MASK))
             .collect();
 
         if match_opcode.len() == 1 {
@@ -47,18 +43,16 @@ fn get_instruction_block_prefix(instruction: u8) -> u8 {
         }
     }
 
-    // Sinon, vérifier si l'instruction appartient au groupe PREFIX1 (RLC, RRC, etc.)
     let match_opcode: Vec<u8> = INSTRUCTIONS_BLOCK_PREFIX1
         .iter()
         .cloned()
-        .filter(|&opcode| (instruction & block_prefix_mask1) == (opcode & block_prefix_mask1))
+        .filter(|&opcode| (instruction & MIDDLE_3_BITS_MASK) == (opcode & MIDDLE_3_BITS_MASK))
         .collect();
 
     if match_opcode.len() == 1 {
         return match_opcode[0];
     }
 
-    // Si aucune correspondance unique n'est trouvée
     panic!("No unique instruction found for opcode: {instruction:#04x}");
 }
 

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -8,6 +8,8 @@ use crate::cpu::Cpu;
 use crate::mmu::Mmu;
 use crate::ppu::Ppu;
 
+const FRAME_CYCLES: u32 = 70224;
+
 #[derive(Default)]
 pub struct GameBoy {
     pub cpu: Cpu,
@@ -27,7 +29,7 @@ impl GameBoy {
     pub fn run_frame(&mut self) -> Vec<u8> {
         let mut cycles_this_frame = 0;
 
-        while cycles_this_frame < 70224 {
+        while cycles_this_frame < FRAME_CYCLES {
             self.bus.borrow_mut().tick_timers();
             self.cpu.tick();
             cycles_this_frame += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         args.pop()
             .expect("Expected a ROM name as the second argument")
     } else {
-        "roms/cpu_instrs.gb".to_string()
+        "roms/individual/02-interrupts.gb".to_string()
     };
 
     let rom_data: Vec<u8> = read_rom(rom_path);

--- a/src/mmu/interrupt.rs
+++ b/src/mmu/interrupt.rs
@@ -38,7 +38,7 @@ impl InterruptController {
         self.ienable & 0b00011111
     }
 
-    pub fn write_ie(&mut self, val: u8) {
+    pub fn write_interrupt_enable(&mut self, val: u8) {
         self.ienable = val & 0b00011111;
     }
 
@@ -46,7 +46,7 @@ impl InterruptController {
         self.iflag | 0b11100000
     }
 
-    pub fn write_if(&mut self, val: u8) {
+    pub fn write_interrupt_flag(&mut self, val: u8) {
         self.iflag = val & 0b00011111;
     }
 
@@ -88,22 +88,22 @@ mod tests {
     }
 
     #[test]
-    fn test_read_write_ie() {
+    fn test_read_write_interrupt_enable() {
         let mut ic = InterruptController::new();
         assert_eq!(ic.read_interrupt_enable(), 0);
-        ic.write_ie(0b1111_1111);
+        ic.write_interrupt_enable(0b1111_1111);
         assert_eq!(ic.read_interrupt_enable(), 0b0001_1111);
-        ic.write_ie(0b0000_0101);
+        ic.write_interrupt_enable(0b0000_0101);
         assert_eq!(ic.read_interrupt_enable(), 0b0000_0101);
     }
 
     #[test]
-    fn test_read_write_if() {
+    fn test_read_write_interrupt_flag() {
         let mut ic = InterruptController::new();
         assert_eq!(ic.read_interrupt_flag(), 0b1110_0000);
-        ic.write_if(0b1010_1010);
+        ic.write_interrupt_flag(0b1010_1010);
         assert_eq!(ic.read_interrupt_flag(), 0b1110_1010);
-        ic.write_if(0);
+        ic.write_interrupt_flag(0);
         assert_eq!(ic.read_interrupt_flag(), 0b1110_0000);
     }
 
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn test_next_request_priority_and_masking() {
         let mut ic = InterruptController::new();
-        ic.write_ie(
+        ic.write_interrupt_enable(
             (Interrupt::VBlank as u8) | (Interrupt::Timer as u8) | (Interrupt::Joypad as u8),
         );
         for &int in &[

--- a/src/mmu/mbc.rs
+++ b/src/mmu/mbc.rs
@@ -1,5 +1,7 @@
 use std::cmp::min;
 
+const ROM_BANK_SIZE: usize = 0x4000;
+
 #[derive(Clone)]
 pub struct Mbc {
     banks: Vec<[u8; 0x4000]>,
@@ -12,17 +14,17 @@ impl Mbc {
         let mut offset = 0;
 
         while offset < rom_image.len() {
-            let mut bank = [0u8; 0x4000];
+            let mut bank = [0u8; ROM_BANK_SIZE];
 
-            let end = min(offset + 0x4000, rom_image.len());
+            let end = min(offset + ROM_BANK_SIZE, rom_image.len());
             let len = end - offset;
 
             bank[..len].copy_from_slice(&rom_image[offset..end]);
             banks.push(bank);
-            offset += 0x4000;
+            offset += ROM_BANK_SIZE;
         }
         if banks.len() < 2 {
-            banks.resize(2, [0u8; 0x4000]);
+            banks.resize(2, [0u8; ROM_BANK_SIZE]);
         }
 
         Mbc { banks, current: 1 }
@@ -31,10 +33,10 @@ impl Mbc {
     pub fn read(&self, addr: u16) -> u8 {
         let i = addr as usize;
 
-        if i < 0x4000 {
+        if i < ROM_BANK_SIZE {
             self.banks[0][i]
         } else {
-            let off = i - 0x4000;
+            let off = i - ROM_BANK_SIZE;
 
             self.banks[self.current][off]
         }

--- a/src/ppu/colors_palette.rs
+++ b/src/ppu/colors_palette.rs
@@ -1,0 +1,40 @@
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+pub enum Color {
+    White,
+    LightGray,
+    DarkGray,
+    Black,
+}
+
+impl Color {
+    pub fn to_rgb(&self) -> [u8; 3] {
+        match self {
+            Color::White => [255, 255, 255],
+            Color::LightGray => [192, 192, 192],
+            Color::DarkGray => [96, 96, 96],
+            Color::Black => [0, 0, 0],
+        }
+    }
+
+    pub fn from_rgb(rgb: [u8; 3]) -> Self {
+        match rgb {
+            [255, 255, 255] => Color::White,
+            [192, 192, 192] => Color::LightGray,
+            [96, 96, 96] => Color::DarkGray,
+            [0, 0, 0] => Color::Black,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn from_index(index: u8) -> Self {
+        match index {
+            0 => Color::White,
+            1 => Color::LightGray,
+            2 => Color::DarkGray,
+            3 => Color::Black,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/ppu/lcd_control.rs
+++ b/src/ppu/lcd_control.rs
@@ -3,106 +3,118 @@
 
 use std::ops::Range;
 
+pub const TILE_MAP_0: Range<u16> = 0x9800..0x9C00;
+pub const TILE_MAP_1: Range<u16> = 0x9C00..0xA000;
+
+pub const TILE_DATA_0: Range<u16> = 0x8800..0x9800;
+pub const TILE_DATA_1: Range<u16> = 0x8000..0x9000;
+
+const PPU_ENABLE_MASK: u8 = 0b1000_0000;
+const WINDOW_TILE_MAP_MASK: u8 = 0b0100_0000;
+const WINDOW_ENABLE_MASK: u8 = 0b0010_0000;
+const BG_WINDOW_TILE_DATA_MASK: u8 = 0b0001_0000;
+const BG_TILE_MAP_MASK: u8 = 0b0000_1000;
+const OBJ_SIZE_MASK: u8 = 0b0000_0100;
+const OBJ_ENABLE_MASK: u8 = 0b0000_0010;
+const BG_WINDOW_ENABLE_MASK: u8 = 0b0000_0001;
+
 #[derive(Default)]
 pub struct LcdControl {
     ppu_enable: bool,
     window_tile_map_area: bool,
     window_enable: bool,
-    bg_window_tiles: bool,
-    bg_tile_map: bool,
-    obj_size: bool,
+    bg_window_tile_data_area: bool,
+    bg_tile_map_area: bool,
+    obj_size_8x16: bool,
     obj_enable: bool,
     bg_window_enable: bool,
 }
 
 impl LcdControl {
-    pub fn set_ppu_enable(&mut self, enable: bool) {
+    pub fn enable_ppu(&mut self, enable: bool) {
         self.ppu_enable = enable;
     }
 
-    pub fn set_window_tile_map_area(&mut self, area: bool) {
-        self.window_tile_map_area = area;
+    pub fn select_window_tile_map(&mut self, use_map1: bool) {
+        self.window_tile_map_area = use_map1;
     }
 
-    pub fn set_window_enable(&mut self, enable: bool) {
+    pub fn enable_window(&mut self, enable: bool) {
         self.window_enable = enable;
     }
 
-    pub fn set_bg_window_tiles(&mut self, tiles: bool) {
-        self.bg_window_tiles = tiles;
+    pub fn select_bg_window_tile_data(&mut self, use_data1: bool) {
+        self.bg_window_tile_data_area = use_data1;
     }
 
-    pub fn set_bg_tile_map(&mut self, map: bool) {
-        self.bg_tile_map = map;
+    pub fn select_bg_tile_map(&mut self, use_map1: bool) {
+        self.bg_tile_map_area = use_map1;
     }
 
-    pub fn set_obj_size(&mut self, size: bool) {
-        self.obj_size = size;
+    pub fn set_obj_size_8x16(&mut self, is_8x16: bool) {
+        self.obj_size_8x16 = is_8x16;
     }
 
-    pub fn set_obj_enable(&mut self, enable: bool) {
+    pub fn enable_obj(&mut self, enable: bool) {
         self.obj_enable = enable;
     }
 
-    pub fn set_bg_window_enable(&mut self, enable: bool) {
+    pub fn enable_bg_window(&mut self, enable: bool) {
         self.bg_window_enable = enable;
     }
 
-    pub fn get_ppu_enable(&self) -> bool {
+    pub fn is_ppu_enabled(&self) -> bool {
         self.ppu_enable
     }
 
-    pub fn get_window_tile_map_area(&self) -> Range<u16> {
+    pub fn window_tile_map_area(&self) -> Range<u16> {
         if self.window_tile_map_area {
-            0x9C00..0x9F00
+            TILE_MAP_1
         } else {
-            0x9800..0x9BFF
+            TILE_MAP_0
         }
     }
 
-    pub fn get_window_enable(&self) -> bool {
+    pub fn is_window_enabled(&self) -> bool {
         self.window_enable
     }
 
-    pub fn get_bg_window_tiles(&self) -> bool {
-        self.bg_window_tiles
-    }
-
-    pub fn get_bg_window_tiles_area(&self) -> Range<u16> {
-        if self.bg_window_tiles {
-            0x8000..0x8FFF
+    pub fn bg_window_tile_data_area(&self) -> Range<u16> {
+        if self.bg_window_tile_data_area {
+            TILE_DATA_1
         } else {
-            0x8800..0x97FF
+            TILE_DATA_0
         }
     }
 
-    pub fn get_bg_tile_map(&self) -> Range<u16> {
-        if self.bg_tile_map {
-            0x9c00..0x9FFF
+    pub fn bg_tile_map_area(&self) -> Range<u16> {
+        if self.bg_tile_map_area {
+            TILE_MAP_1
         } else {
-            0x9800..0x9BFF
+            TILE_MAP_0
         }
     }
 
-    pub fn get_obj_size(&self) -> bool {
-        self.obj_size
+    pub fn is_obj_size_8x16(&self) -> bool {
+        self.obj_size_8x16
     }
 
-    pub fn get_obj_enable(&self) -> bool {
+    pub fn is_obj_enabled(&self) -> bool {
         self.obj_enable
     }
-    pub fn get_bg_window_enable(&self) -> bool {
+
+    pub fn is_bg_window_enabled(&self) -> bool {
         self.bg_window_enable
     }
 
-    pub fn update(&mut self, value: u8) {
-        self.ppu_enable = value & 0b1000_0000 != 0;
-        self.window_tile_map_area = value & 0b0100_0000 != 0;
-        self.window_enable = value & 0b0010_0000 != 0;
-        self.bg_window_tiles = value & 0b0001_0000 != 0;
-        self.bg_tile_map = value & 0b0000_1000 != 0;
-        self.obj_size = value & 0b0000_0100 != 0;
-        self.obj_enable = value & 0b0000_0010 != 0;
-        self.bg_window_enable = value & 0b0000_0001 != 0;
+    pub fn update_from_byte(&mut self, value: u8) {
+        self.ppu_enable = value & PPU_ENABLE_MASK != 0;
+        self.window_tile_map_area = value & WINDOW_TILE_MAP_MASK != 0;
+        self.window_enable = value & WINDOW_ENABLE_MASK != 0;
+        self.bg_window_tile_data_area = value & BG_WINDOW_TILE_DATA_MASK != 0;
+        self.bg_tile_map_area = value & BG_TILE_MAP_MASK != 0;
+        self.obj_size_8x16 = value & OBJ_SIZE_MASK != 0;
+        self.obj_enable = value & OBJ_ENABLE_MASK != 0;
+        self.bg_window_enable = value & BG_WINDOW_ENABLE_MASK != 0;
     }
 }

--- a/src/ppu/lcd_status.rs
+++ b/src/ppu/lcd_status.rs
@@ -1,6 +1,15 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum PpuMode {
+    #[default]
+    HBlank = 0,
+    VBlank = 1,
+    OamSearch = 2,
+    PixelTransfer = 3,
+}
+
 #[derive(Default)]
 pub struct LcdStatus {
     lyc_int_select: bool,
@@ -8,7 +17,7 @@ pub struct LcdStatus {
     mode_1_int_select: bool,
     mode_0_int_select: bool,
     lyc_equals_ly: bool,
-    ppu_mode: u8, // 0: H-Blank, 1: V-Blank, 2: OAM Search, 3: Pixel Transfer
+    ppu_mode: PpuMode,
 }
 
 impl LcdStatus {
@@ -19,11 +28,11 @@ impl LcdStatus {
             mode_1_int_select: false,
             mode_0_int_select: false,
             lyc_equals_ly: false,
-            ppu_mode: 0, // Default to H-Blank
+            ppu_mode: PpuMode::HBlank,
         }
     }
 
-    pub fn update_ppu_mode(&mut self, mode: u8) {
+    pub fn update_ppu_mode(&mut self, mode: PpuMode) {
         self.ppu_mode = mode;
     }
 


### PR DESCRIPTION


This PR improves code readability and maintainability by:

- Replacing magic numbers with named constants
- Renaming variables with unclear or non-explicit names
- Splitting a too-long function into smaller, focused functions

Feel free to suggest or make any changes if you think improvements are needed.
