### PR TITLE
feat: add input communication to game thread

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 #![allow(unreachable_code)]
 
 use crate::gameboy::GameBoy;
-use crate::gui::{DebugCommandQueries, DebugResponse, WatchedAdresses};
+use crate::gui::{DebugCommandQueries, DebugResponse, KeyInput, WatchedAdresses};
 use crate::ppu;
 use std::sync::Mutex;
 use std::sync::{
@@ -96,7 +96,7 @@ impl GameApp {
             .try_send(DebugResponse::NextInstructions(v));
     }
 
-    pub fn update(&mut self) -> bool {
+    pub fn update(&mut self, keys_down: &KeyInput) -> bool {
         let mut instruction_to_execute = !self.is_step_mode as usize;
         let is_debug = self.is_debug_mode.load(Ordering::Relaxed);
         if is_debug {
@@ -158,14 +158,14 @@ impl GameApp {
         let mut frame_was_edited = false;
         if is_debug {
             for _ in 0..instruction_to_execute {
-                frame_was_edited = self.gameboy.run_frame();
+                frame_was_edited = self.gameboy.run_frame(keys_down);
                 self.send_next_instructions();
                 self.send_watched_address();
                 self.send_registers();
             }
             frame_was_edited
         } else {
-            self.gameboy.run_frame()
+            self.gameboy.run_frame(keys_down)
         }
     }
 

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -8,6 +8,7 @@ use std::sync::Mutex;
 use tokio::time::Instant;
 
 use crate::cpu::Cpu;
+use crate::gui::KeyInput;
 use crate::mmu::Mmu;
 use crate::ppu::Ppu;
 
@@ -33,8 +34,10 @@ impl GameBoy {
         GameBoy { cpu, bus, ppu, image }
     }
 
-    pub fn run_frame(&mut self) -> bool {
+    pub fn run_frame(&mut self, key_input: &KeyInput) -> bool {
         let mut frame = false;
+
+        // TODO -> make interuption with key_input 
 
         let debut = Instant::now();
         for i in 0..17556 {

--- a/src/gui/common.rs
+++ b/src/gui/common.rs
@@ -7,3 +7,4 @@ pub fn display_game(texture: SizedTexture, ctx: &Context) {
         });
     });
 }
+

--- a/src/gui/views/emulation_view.rs
+++ b/src/gui/views/emulation_view.rs
@@ -1,13 +1,12 @@
-use crate::{
-    gui::{
-        AppState, CoreGameDevice, DebugingDevice, EmulationDevice, SelectionDevice, WatchedAdresses,
-    },
-};
-use eframe::egui::Context;
+use crate::gui::{
+        AppState, CoreGameDevice, DebugingDevice, EmulationDevice, SelectionDevice, WatchedAdresses
+    };
+use eframe::egui::{Context, ahash::HashSet};
+use std::thread::sleep;
 
 use std::sync::atomic::Ordering;
 
-use std::time::Instant;
+use std::time::{Instant, Duration};
 
 impl EmulationDevice {
     pub fn emulation_view(mut self, ctx: &Context, _frame: &mut eframe::Frame) -> AppState {
@@ -15,6 +14,9 @@ impl EmulationDevice {
         self.core_game.update_and_size_image(ctx);
         let duration = debut.elapsed();
         //println!("update and size image: Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
+        let input = self.core_game.capture_input(ctx);
+
+        self.core_game.input_sender.send(input);
 
         eframe::egui::CentralPanel::default()
             .show(ctx, |ui| {


### PR DESCRIPTION
Ajout de deux structure ayant pour but de faciliter les inputs utilisateur. 

KeyInput -> represente les boutons de la gameboy appuye a un instant donne
KeyMapping -> permet de mapper des touches sur les controle de la gameboy. 

le CoreGameDevice expose maintenant la possibilite de traduire les key down donne par le context egui en objet Input au travers de son Mapping.

Je cree une nouvelle issue pour permettre le remapping des touches a partir de l'interface graphique. 