### PR TITLE
87 feat implementer le comportement des modes du ppu et le ticking

### DIFF
--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -35,22 +35,24 @@ impl GameBoy {
     }
 
     pub fn run_frame(&mut self, key_input: &KeyInput) -> bool {
-        let mut frame = false;
+        let mut cycles_elapsed = 0;
 
-        // TODO -> make interuption with key_input 
-
-        let debut = Instant::now();
-        for i in 0..17556 {
+        while cycles_elapsed < FRAME_CYCLES {
+            // 1. Tick Timers
             self.bus.write().unwrap().tick_timers();
+
+            // 2. Tick CPU
             self.cpu.tick();
 
+            // 3. Tick PPU
             let vblank = self.ppu.tick(4, &mut self.image);
 
             if vblank {
                 return true;
             }
-        }
 
+            cycles_elapsed += 1;
+        }
         false
     }
 }

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -42,23 +42,15 @@ impl GameBoy {
         let debut = Instant::now();
         for i in 0..17556 {
             self.bus.write().unwrap().tick_timers();
-            let duration = debut.elapsed();
-            //println!("bus tick : Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
-            let debut = Instant::now();
             self.cpu.tick();
-            let duration = debut.elapsed();
-            //println!("cpu tick : Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
-            let debut = Instant::now();
-            self.ppu.update_registers();
-            let duration = debut.elapsed();
-            //println!("update_reg : Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
+
+            let vblank = self.ppu.tick(4, &mut self.image);
+
+            if vblank {
+                return true;
+            }
         }
-        let duration = debut.elapsed();
-        //println!("one cpu render frame : Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
-        let debut = Instant::now();
-        self.ppu.render_frame(&mut self.image);
-        let duration = debut.elapsed();
-        //println!("render : Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
-        true
+
+        false
     }
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -74,13 +74,15 @@ pub struct Mmu {
 
 impl Mmu {
     pub fn new(rom_image: &[u8]) -> Self {
-        Mmu {
+        let mmu = Mmu {
             data: [0; 0x10000],
             cart: Mbc::new(rom_image),
             interrupts: InterruptController::new(),
             timers: Timers::default(),
             oam: Oam::default(),
-        }
+        };
+
+       mmu
     }
 
     pub fn tick_timers(&mut self) {
@@ -95,6 +97,7 @@ impl Mmu {
     pub fn read_byte(&self, addr: u16) -> u8 {
         match MemoryRegion::from(addr) {
             MemoryRegion::Mbc => self.cart.read(addr),
+            MemoryRegion::Timers => self.timers.read_byte(addr),
             MemoryRegion::Mram => {
                 let mirror = addr - 0x2000;
 

--- a/src/ppu/lcd_status.rs
+++ b/src/ppu/lcd_status.rs
@@ -3,9 +3,9 @@
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum PpuMode {
-    #[default]
     HBlank = 0,
     VBlank = 1,
+    #[default]
     OamSearch = 2,
     PixelTransfer = 3,
 }
@@ -28,7 +28,7 @@ impl LcdStatus {
             mode_1_int_select: false,
             mode_0_int_select: false,
             lyc_equals_ly: false,
-            ppu_mode: PpuMode::HBlank,
+            ppu_mode: PpuMode::OamSearch,
         }
     }
 

--- a/src/ppu/lcd_status.rs
+++ b/src/ppu/lcd_status.rs
@@ -43,4 +43,51 @@ impl LcdStatus {
     pub fn set_lyc_equals_ly(&mut self, equals: bool) {
         self.lyc_equals_ly = equals;
     }
+
+    pub fn get_lyc_equals_ly(&self) -> bool {
+        self.lyc_equals_ly
+    }
+
+    pub fn struct_to_byte(&self) -> u8 {
+        let mut stat = 0u8;
+
+        // Bit 6: LYC interrupt enable
+        if self.lyc_int_select {
+            stat |= 0b0100_0000;
+        }
+
+        // Bit 5: Mode 2 interrupt enable
+        if self.mode_2_int_select {
+            stat |= 0b0010_0000;
+        }
+
+        // Bit 4: Mode 1 interrupt enable
+        if self.mode_1_int_select {
+            stat |= 0b0001_0000;
+        }
+
+        // Bit 3: Mode 0 interrupt enable
+        if self.mode_0_int_select {
+            stat |= 0b0000_1000;
+        }
+
+        // Bit 2: LYC == LY flag (read-only)
+        if self.lyc_equals_ly {
+            stat |= 0b0000_0100;
+        }
+
+        // Bits 1-0: PPU mode
+        stat |= self.ppu_mode as u8;
+
+        stat
+    }
+
+    pub fn update_from_byte(&mut self, value: u8) {
+        self.lyc_int_select = (value & 0b0100_0000) != 0;
+        self.mode_2_int_select = (value & 0b0010_0000) != 0;
+        self.mode_1_int_select = (value & 0b0001_0000) != 0;
+        self.mode_0_int_select = (value & 0b0000_1000) != 0;
+
+        // Bits 2, 1, 0 are read-only
+    }
 }


### PR DESCRIPTION
- LYC == LY est maintenant checké à chaque fois que la ligne (LY) change
- Le PPU tick maintenant de façon synchronisée avec le CPU (1 cycle CPU = 4 cycles PPU)
- Le PPU alterne correctement entre ses 4 modes (OAM Search, Pixel Transfer, Hblank, Vblank).

**Ce qui reste à implémenter**:
- Les restrictions d'accès mémoire selon les modes (peu urgent)
- Le timing du Pixel transfer est supposé être entre 172–289 dots, et celui du Hblank entre 87–204 dots, de façon proportionnelle pour que le total fasse 456 (avec OAM). Pour le moment le Pixel Transfer vaut toujours 172 et Hblank toujours 204.