### PR TITLE
41 feat les cartridges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -872,6 +872,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1236,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1810,6 +1823,7 @@ dependencies = [
 name = "gbmu"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "eframe",
  "egui 0.31.1",
  "egui_extras",
@@ -2181,6 +2195,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ eframe = "0.25"
 tokio = { version = "1.46.1", features = ["full"] }
 egui_extras = "0.33.0"
 flamegraph = "0.6.11"
+chrono = "0.4.43"

--- a/src/cpu/block2.rs
+++ b/src/cpu/block2.rs
@@ -4,6 +4,7 @@
 use crate::cpu::Cpu;
 use crate::cpu::registers::R8;
 use crate::cpu::utils;
+use crate::mmu::mbc::Mbc;
 
 const R16_MASK: u8 = 0b00110000;
 const R8_MASK: u8 = 0b00111000;
@@ -35,7 +36,7 @@ fn get_instruction_block2(instruction: u8) -> u8 {
     }
 }
 
-pub fn execute_instruction_block2(cpu: &mut Cpu, instruction: u8) -> u8 {
+pub fn execute_instruction_block2<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8) -> u8 {
     let opcode = get_instruction_block2(instruction);
 
     match opcode {
@@ -56,7 +57,7 @@ pub fn execute_instruction_block2(cpu: &mut Cpu, instruction: u8) -> u8 {
     }
 }
 
-fn add_a_r8(cpu: &mut Cpu, instruction: u8, with_carry: bool) {
+fn add_a_r8<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8, with_carry: bool) {
     let r8: R8 = utils::convert_source_index_to_r8(instruction);
 
     let r8_value = cpu.get_r8_value(r8);
@@ -64,7 +65,7 @@ fn add_a_r8(cpu: &mut Cpu, instruction: u8, with_carry: bool) {
     cpu.pc = cpu.pc.wrapping_add(1)
 }
 
-fn sub_a_r8(cpu: &mut Cpu, instruction: u8, with_carry: bool) {
+fn sub_a_r8<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8, with_carry: bool) {
     let r8: R8 = utils::convert_source_index_to_r8(instruction);
 
     let r8_value = cpu.get_r8_value(r8);
@@ -72,7 +73,7 @@ fn sub_a_r8(cpu: &mut Cpu, instruction: u8, with_carry: bool) {
     cpu.pc = cpu.pc.wrapping_add(1)
 }
 
-fn and_a_r8(cpu: &mut Cpu, instruction: u8) {
+fn and_a_r8<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8) {
     let r8: R8 = utils::convert_source_index_to_r8(instruction);
 
     let r8_value = cpu.get_r8_value(r8);
@@ -89,7 +90,7 @@ fn and_a_r8(cpu: &mut Cpu, instruction: u8) {
     cpu.pc = cpu.pc.wrapping_add(1)
 }
 
-fn xor_a_r8(cpu: &mut Cpu, instruction: u8) {
+fn xor_a_r8<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8) {
     let r8: R8 = utils::convert_source_index_to_r8(instruction);
 
     let r8_value = cpu.get_r8_value(r8);
@@ -106,7 +107,7 @@ fn xor_a_r8(cpu: &mut Cpu, instruction: u8) {
     cpu.pc = cpu.pc.wrapping_add(1)
 }
 
-fn or_a_r8(cpu: &mut Cpu, instruction: u8) {
+fn or_a_r8<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8) {
     let r8: R8 = utils::convert_source_index_to_r8(instruction);
 
     let r8_value = cpu.get_r8_value(r8);
@@ -123,7 +124,7 @@ fn or_a_r8(cpu: &mut Cpu, instruction: u8) {
     cpu.pc = cpu.pc.wrapping_add(1)
 }
 
-fn cp_a_r8(cpu: &mut Cpu, instruction: u8) {
+fn cp_a_r8<T: Mbc>(cpu: &mut Cpu<T>, instruction: u8) {
     let r8: R8 = utils::convert_source_index_to_r8(instruction);
 
     let r8_value = cpu.get_r8_value(r8);
@@ -143,11 +144,11 @@ fn cp_a_r8(cpu: &mut Cpu, instruction: u8) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cpu::Cpu;
+    use crate::{cpu::Cpu, mmu::mbc::RomOnly};
 
     #[test]
     fn test_add_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0x10);
         cpu.set_r8_value(R8::B, 0x20);
         execute_instruction_block2(&mut cpu, 0x80); // ADD A, B
@@ -158,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_adc_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0x10);
         cpu.set_r8_value(R8::C, 0x20);
         cpu.registers.set_carry_flag(true);
@@ -170,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_sub_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0x30);
         cpu.set_r8_value(R8::C, 0x10);
         execute_instruction_block2(&mut cpu, 0x91); // SUB A, C
@@ -181,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_sbc_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0x30);
         cpu.set_r8_value(R8::E, 0x10);
         cpu.registers.set_carry_flag(true);
@@ -193,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_and_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0b1100);
         cpu.set_r8_value(R8::D, 0b1010);
         execute_instruction_block2(&mut cpu, 0xA2); // AND A, D
@@ -204,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_xor_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0b1100);
         cpu.set_r8_value(R8::E, 0b1010);
         execute_instruction_block2(&mut cpu, 0xAB); // XOR A, E
@@ -215,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_or_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0b1100);
         cpu.set_r8_value(R8::H, 0b1010);
         execute_instruction_block2(&mut cpu, 0xB4); // OR A, H
@@ -226,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_cp_a_r8() {
-        let mut cpu = Cpu::default();
+        let mut cpu = Cpu::<RomOnly>::default();
         cpu.set_r8_value(R8::A, 0x20);
         cpu.set_r8_value(R8::L, 0x20);
         execute_instruction_block2(&mut cpu, 0xBD); // CP A, L

--- a/src/cpu/ops8.rs
+++ b/src/cpu/ops8.rs
@@ -1,7 +1,8 @@
 use crate::cpu::registers::R8;
 use crate::cpu::Cpu;
+use crate::mmu::mbc::Mbc;
 
-impl Cpu {
+impl<T: Mbc> Cpu<T> {
     pub fn op_rotate_left(&mut self, target: R8, through_carry: bool, z_always_zero: bool) {
         let value = self.get_r8_value(target);
 
@@ -77,7 +78,7 @@ impl Cpu {
 
     pub fn op_swap(&mut self, target: R8) {
         let value = self.get_r8_value(target);
-        let result = (value >> 4) | (value << 4);
+        let result = value.rotate_left(4);
 
         self.set_r8_value(target, result);
         self.registers.set_zero_flag(result == 0);
@@ -92,12 +93,13 @@ impl Cpu {
 mod tests {
     use crate::cpu::registers::{R8, R16};
     use crate::cpu::Cpu;
+    use crate::mmu::mbc::RomOnly;
     use crate::mmu::Mmu;
     use std::sync::{Arc, RwLock};
 
-    fn cpu_with_mem_at_hl(initial: u8) -> Cpu {
+    fn cpu_with_mem_at_hl(initial: u8) -> Cpu<RomOnly> {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus.clone());
+        let mut cpu = Cpu::<RomOnly>::new(bus.clone());
 
         // Place HL somewhere in WRAM so boot ROM mapping can't interfere
         cpu.registers.set_r16_value(R16::HL, 0xC000);
@@ -108,7 +110,7 @@ mod tests {
         cpu
     }
 
-    fn mem_at_hl(cpu: &Cpu) -> u8 {
+    fn mem_at_hl(cpu: &Cpu<RomOnly>) -> u8 {
         let addr = cpu.registers.get_r16_value(R16::HL);
         cpu.bus.read().unwrap().read_byte(addr)
     }
@@ -118,7 +120,7 @@ mod tests {
     #[test]
     fn rlc_on_register_sets_carry_and_result_and_flags() {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus);
+        let mut cpu = Cpu::<RomOnly>::new(bus);
 
         cpu.set_r8_value(R8::B, 0b1000_0001);
 
@@ -147,7 +149,7 @@ mod tests {
     #[test]
     fn rlc_sets_zero_when_result_is_zero_unless_forced() {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus);
+        let mut cpu = Cpu::<RomOnly>::new(bus);
 
         cpu.set_r8_value(R8::C, 0x00);
 
@@ -165,7 +167,7 @@ mod tests {
     #[test]
     fn rl_through_carry_uses_old_carry_as_bit0() {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus);
+        let mut cpu = Cpu::<RomOnly>::new(bus);
 
         cpu.set_r8_value(R8::D, 0b1000_0000);
         cpu.registers.set_carry_flag(true);
@@ -212,7 +214,7 @@ mod tests {
     #[test]
     fn srl_shifts_in_zero_and_sets_carry_from_bit0() {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus);
+        let mut cpu = Cpu::<RomOnly>::new(bus);
 
         cpu.set_r8_value(R8::E, 0b0000_0001);
 
@@ -228,7 +230,7 @@ mod tests {
     #[test]
     fn sra_preserves_sign_bit() {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus);
+        let mut cpu = Cpu::<RomOnly>::new(bus);
 
         cpu.set_r8_value(R8::H, 0b1000_0001);
 
@@ -260,7 +262,7 @@ mod tests {
     #[test]
     fn swap_sets_zero_when_result_is_zero() {
         let bus = Arc::new(RwLock::new(Mmu::default()));
-        let mut cpu = Cpu::new(bus);
+        let mut cpu = Cpu::<RomOnly>::new(bus);
 
         cpu.set_r8_value(R8::A, 0x00);
         cpu.op_swap(R8::A);

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -3,6 +3,7 @@
 
 use crate::cpu::conditions::Cond;
 use crate::cpu::flags_registers::FlagsRegister;
+use crate::mmu::mbc::Mbc;
 use crate::mmu::Mmu;
 
 #[repr(u8)]
@@ -180,7 +181,7 @@ impl Registers {
         }
     }
 
-    pub fn set_r16_mem_value(&mut self, memory: &mut Mmu, target: R16, value: u8) {
+    pub fn set_r16_mem_value<T: Mbc>(&mut self, memory: &mut Mmu<T>, target: R16, value: u8) {
         let addr = match target {
             R16::BC => self.get_bc(),
             R16::DE => self.get_de(),
@@ -190,7 +191,7 @@ impl Registers {
         memory.write_byte(addr, value);
     }
 
-    pub fn get_r16_mem_value(&self, memory: &Mmu, target: R16) -> u8 {
+    pub fn get_r16_mem_value<T: Mbc>(&self, memory: &Mmu<T>, target: R16) -> u8 {
         let addr = match target {
             R16::BC => self.get_bc(),
             R16::DE => self.get_de(),
@@ -418,7 +419,7 @@ impl Registers {
         self.sp = value;
     }
 
-    pub fn push_sp(&mut self, bus: &mut Mmu, value: u16) {
+    pub fn push_sp<T: Mbc>(&mut self, bus: &mut Mmu<T>, value: u16) {
         let low = (value & 0x00FF) as u8;
         let high = (value >> 8) as u8;
         self.sp = self.sp.wrapping_sub(1);
@@ -427,7 +428,7 @@ impl Registers {
         bus.write_byte(self.sp, low);
     }
 
-    pub fn pop_sp(&mut self, bus: &Mmu) -> u16 {
+    pub fn pop_sp<T: Mbc>(&mut self, bus: &Mmu<T>) -> u16 {
         let low = bus.read_byte(self.sp) as u16;
         let high = bus.read_byte(self.sp.wrapping_add(1)) as u16;
         self.sp = self.sp.wrapping_add(2);

--- a/src/cpu/utils.rs
+++ b/src/cpu/utils.rs
@@ -1,13 +1,14 @@
 use crate::cpu::Cpu;
 use crate::cpu::conditions::Cond;
 use crate::cpu::registers::{R8, R16, R16Mem};
+use crate::mmu::mbc::Mbc;
 
 pub const R16_MASK: u8 = 0b00110000;
 pub const DEST_R8_MASK: u8 = 0b00111000;
 pub const SOURCE_R8_MASK: u8 = 0b00000111;
 pub const COND_MASK: u8 = 0b00011000;
 
-pub fn get_imm16(cpu: &mut Cpu) -> u16 {
+pub fn get_imm16<T: Mbc>(cpu: &mut Cpu<T>) -> u16 {
     let lsb = cpu.bus.read().unwrap().read_byte(cpu.pc + 1) as u16;
     let msb = cpu.bus.read().unwrap().read_byte(cpu.pc + 2) as u16;
     (msb << 8) | lsb
@@ -38,7 +39,7 @@ pub fn convert_index_to_cond(instruction: u8) -> Cond {
     Cond::from(cond_index)
 }
 
-pub fn modify_hl(cpu: &mut Cpu, r16_mem: R16Mem) {
+pub fn modify_hl<T: Mbc>(cpu: &mut Cpu<T>, r16_mem: R16Mem) {
     let value = cpu.registers.get_r16_value(R16::HL);
 
     if r16_mem == R16Mem::HLincrement {

--- a/src/gui/views/debuging_view.rs
+++ b/src/gui/views/debuging_view.rs
@@ -4,7 +4,7 @@ use crate::debugger::debbuger;
 use crate::gui::{AppState, DebugingDevice, WatchedAdresses};
 
 use eframe::egui::load::SizedTexture;
-use eframe::egui::{Context, TextureHandle, TextureOptions};
+use eframe::egui::Context;
 
 use display::display_interface;
 
@@ -73,7 +73,7 @@ impl DebugingDevice {
     }
 
     fn update_and_get_debuging_data(&mut self, ctx: &Context) -> DebugingDataIn<'_> {
-        let color_image = self.core_game.update_and_size_image(ctx);
+        self.core_game.update_and_size_image(ctx);
         debbuger::update_info_struct(self);
 
         let error_message = if let Some(value) = &self.error_message {

--- a/src/gui/views/selection_view.rs
+++ b/src/gui/views/selection_view.rs
@@ -89,16 +89,14 @@ impl SelectionDevice {
                 if entry_as_path.is_dir() {
                     enterable = true;
                 }
-                if let Some(extension) = entry_as_path.extension() {
-                    if extension == "gb" {
+                if let Some(extension) = entry_as_path.extension()
+                    && extension == "gb" {
                         enterable = true;
                     }
-                }
-                if enterable {
-                    if let Some(file_name) = entry.file_name().to_str() {
+                if enterable
+                    && let Some(file_name) = entry.file_name().to_str() {
                         self.files.push(file_name.to_string());
                     }
-                }
             }
             self.files.sort();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod gui;
 mod mmu;
 mod ppu;
 
-use gui::MyApp;
+use gui::GraphicalApp;
 
 #[tokio::main]
 async fn main() {
@@ -21,6 +21,6 @@ async fn main() {
     let _ = eframe::run_native(
         "egui Demo",
         options,
-        Box::new(|_cc| Box::new(MyApp::default())),
+        Box::new(|_cc| Box::new(GraphicalApp::default())),
     );
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -64,9 +64,9 @@ impl MemoryRegion {
     }
 }
 
-pub struct Mmu {
+pub struct Mmu<T: Mbc> {
     data: [u8; 0x10000], // 0xFFFF (65535) + 1 = 0x10000 (65536)
-    cart: Mbc,
+    cart: T,
     interrupts: InterruptController,
     timers: Timers,
     oam: Oam,
@@ -74,19 +74,18 @@ pub struct Mmu {
     boot_rom: [u8; 0x0100]
 }
 
-impl Mmu {
-    pub fn new(rom_image: &[u8]) -> Self {
-        let mmu = Mmu {
+impl<T: Mbc> Mmu<T> {
+    pub fn new(rom_image: &[u8]) -> Result<Self, String> {
+        
+       Ok(Mmu {
             data: [0; 0x10000],
-            cart: Mbc::new(rom_image),
+            cart: T::new(rom_image)?,
             interrupts: InterruptController::new(),
             timers: Timers::default(),
             oam: Oam::default(),
             boot_enable: false,
             boot_rom: [0; 0x0100],
-        };
-
-       mmu
+        })
     }
 
     pub fn load_boot_rom(&mut self, boot_rom: [u8; 0x0100]) {
@@ -109,7 +108,7 @@ impl Mmu {
         }
 
         match MemoryRegion::from(addr) {
-            MemoryRegion::Mbc => self.cart.read(addr),
+            MemoryRegion::Mbc | MemoryRegion::ERam => self.cart.read(addr),
             MemoryRegion::Timers => self.timers.read_byte(addr),
             MemoryRegion::Mram => {
                 let mirror = addr - 0x2000;
@@ -133,7 +132,7 @@ impl Mmu {
         }
 
         match MemoryRegion::from(addr) {
-            MemoryRegion::Mbc => self.cart.write(addr, val),
+            MemoryRegion::Mbc | MemoryRegion::ERam => self.cart.write(addr, val),
             MemoryRegion::Mram => {
                 let mirror = addr - 0x2000;
 
@@ -175,21 +174,23 @@ impl Mmu {
     }
 }
 
-impl Default for Mmu {
+impl<T: Mbc> Default for Mmu<T> {
     fn default() -> Self {
-        Mmu::new(&[])
+        Mmu::<T>::new(&[]).expect("This is not suppose to happen")
     }
 }
 
 // In mmu.rs
 #[cfg(test)]
 mod tests {
+    use crate::mmu::mbc::RomOnly;
+
     use super::{MemoryRegion, Mmu};
 
     #[test]
     fn mmu_routes_reads_and_writes() {
         let rom = vec![0x12, 0x34, 0x56, 0x78];
-        let mut mmu = Mmu::new(&rom);
+        let mut mmu = Mmu::<RomOnly>::new(&rom).unwrap();
 
         // Reading from ROM region gives you the first bank data
         assert_eq!(mmu.read_byte(0x0000), 0x12);
@@ -218,7 +219,7 @@ mod tests {
     // MRAM ECHO RAM
     #[test]
     fn echo_ram_mirror() {
-        let mut mmu = Mmu::new(&[]);
+        let mut mmu = Mmu::<RomOnly>::new(&[]).unwrap();
 
         // Write to Work RAM (0xC000) and read from Echo RAM (0xE000)
         mmu.write_byte(0xC000, 0xAA);
@@ -232,7 +233,7 @@ mod tests {
     // UNUSABLE REGION
     #[test]
     fn unusable_region_behavior() {
-        let mut mmu = Mmu::new(&[]);
+        let mut mmu = Mmu::<RomOnly>::new(&[]).unwrap();
 
         // Unusable region reads back as 0xFF
         let base = 0xFEA0;

--- a/src/mmu/mbc.rs
+++ b/src/mmu/mbc.rs
@@ -1,91 +1,389 @@
 use std::cmp::min;
 
+use chrono::{Local, DateTime};
+const ONLY_ROM_SIZE: usize = 0xC000;
 const ROM_BANK_SIZE: usize = 0x4000;
+const RAM_BANK_SIZE: usize = 0x2000;
 
-#[derive(Clone)]
-pub struct Mbc {
-    banks: Vec<[u8; 0x4000]>,
-    current: usize,
+pub trait Mbc: Default{
+    fn new(rom_image: &[u8]) -> Result<Self, String> where Self: Sized;
+    fn read(&self, addr: u16) -> u8;
+    fn write(&mut self, addr: u16, val: u8);
 }
 
-impl Mbc {
-    pub fn new(rom_image: &[u8]) -> Self {
-        let mut banks = Vec::new();
-        let mut offset = 0;
+#[derive(Clone, Default)]
+pub  struct Mbc1 {
+    banks: Vec<[u8; ROM_BANK_SIZE]>,
+    ram_gate_register: bool, // If ramg is set to 0b1010 -> 
+    bank_register_1: u8,
+    bank_register_2: u8,
+    mode_register: bool,
+    ram_banks: Vec<[u8; RAM_BANK_SIZE]>,
+}
 
-        while offset < rom_image.len() {
-            let mut bank = [0u8; ROM_BANK_SIZE];
-
-            let end = min(offset + ROM_BANK_SIZE, rom_image.len());
-            let len = end - offset;
-
-            bank[..len].copy_from_slice(&rom_image[offset..end]);
-            banks.push(bank);
-            offset += ROM_BANK_SIZE;
-        }
-        if banks.len() < 2 {
-            banks.resize(2, [0u8; ROM_BANK_SIZE]);
-        }
-
-        Mbc { banks, current: 1 }
+fn get_rom_bank_size(rom: &[u8]) -> Result<usize, String>{
+    let code = rom[0x149];
+    match code {
+        0 => Ok(2),
+        1 => Ok(4),
+        2 => Ok(8),
+        3 => Ok(16),
+        4 => Ok(32),
+        5 => Ok(64),
+        6 => Ok(128),
+        7 => Ok(256),
+        8 => Ok(512),
+        _ => Err(format!("Rom size code can't be {}", code))
     }
+}
 
-    pub fn read(&self, addr: u16) -> u8 {
-        let i = addr as usize;
+fn get_ram_bank_size(rom: &[u8]) -> Result<usize, String>{
+    let code = rom[0x148];
+    match code {
+        0 => Ok(0),
+        1 => Ok(0),
+        2 => Ok(1),
+        3 => Ok(4),
+        4 => Ok(16),
+        5 => Ok(8),
+        _ => Err(format!("Ram size code can't be {}", code)),
+    }
+}
 
-        if i < ROM_BANK_SIZE {
-            self.banks[0][i]
+fn map_rom_into_bank(rom_image: &[u8]) -> Result<Vec<[u8; ROM_BANK_SIZE]>, String> {
+    let banks: Vec<[u8; ROM_BANK_SIZE]> = rom_image .chunks_exact(ROM_BANK_SIZE)
+        .map(|slice|{
+            let mut data = [0; ROM_BANK_SIZE];
+            data.copy_from_slice(&slice);
+            data
+        }).collect();
+    let supposed_rom_bank_size = get_rom_bank_size(rom_image)?;
+    if banks.iter().count() != supposed_rom_bank_size {
+        return Err(
+            format!("Inconsistent Rom Header : size must be : {}", supposed_rom_bank_size)
+        );
+    }
+    Ok(banks)
+}
+
+fn map_ram_banks(rom_image: &[u8]) -> Result<Vec<[u8; RAM_BANK_SIZE]>, String> {
+    let supposed_ram_bank_size = get_ram_bank_size(rom_image)?;
+    Ok(vec![[0u8; RAM_BANK_SIZE]; supposed_ram_bank_size])
+}
+
+impl Mbc for Mbc1 {
+    fn new(rom_image: &[u8]) -> Result<Self, String> {
+        let banks = map_rom_into_bank(rom_image)?;
+        let ram_banks = map_ram_banks(rom_image)?;
+        if ram_banks.iter().count() > 4 {
+            Err(
+                format!("Supposed ram bank size can't be more than 4 in mbc1 cartridge.")
+            )
         } else {
-            let off = i - ROM_BANK_SIZE;
+            Ok(Mbc1 {
+                banks,
+                ram_gate_register: false,
+                bank_register_1: 0b1,
+                bank_register_2: 0b0,
+                mode_register: false,
+                ram_banks,
+            })
+        }
 
-            self.banks[self.current][off]
+    }
+
+    fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..0x4000 => {
+                if self.mode_register {
+                    self.banks[0][addr as usize]
+                } else {
+                    self.banks[(self.bank_register_2 << 5) as usize][addr as usize]
+                }
+            },
+            0x4000..0x8000 => {
+                self.banks[
+                    ((self.bank_register_2 << 5) + self.bank_register_1) as usize
+                ][
+                    addr as usize - ROM_BANK_SIZE as usize
+                ]
+            },
+            0xA000..0xC000 => {
+                if self.ram_gate_register {
+                    self.ram_banks[
+                        self.mode_register as usize * self.bank_register_2 as usize
+                    ][addr as usize - 0xA000]
+                } else {
+                    0
+                }
+            },
+            _ => unreachable!()
         }
     }
 
-    pub fn write(&mut self, addr: u16, val: u8) {}
-
-    pub fn bank_count(&self) -> usize {
-        self.banks.len()
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..0x2000 => self.ram_gate_register = (val & 0b1010) == 0b1010,
+            0x2000..0x4000 => self.bank_register_1 = val & 0b11111,
+            0x4000..0x6000 => self.bank_register_2 = val & 0b11,
+            0x6000..0x8000 => self.mode_register = (val & 0b1) == 0b1,
+            0xA000..0xC000 => {
+                if self.ram_gate_register {
+                self.ram_banks[
+                        self.mode_register as usize * self.bank_register_2 as usize
+                    ][addr as usize - 0xA000] = val
+                }
+            },
+            _ => unreachable!()
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::Mbc;
+#[derive(Default)]
+pub struct Mbc2 {
+    rom_banks: Vec<[u8; ROM_BANK_SIZE]>,
+    ram_gate_register: bool,
+    rom_bank_register: u8,
+    ram_banks: Vec<[u8; RAM_BANK_SIZE]>,
+}
 
-    #[test]
-    fn small_rom_creates_two_banks() {
-        let data = vec![0xAA; 100]; // 100 bytes
-        let mbc = Mbc::new(&data);
-
-        // Should have at least two banks
-        assert_eq!(mbc.banks.len(), 2);
-        // First bank begins with your data...
-        for i in 0..100 {
-            assert_eq!(mbc.banks[0][i], 0xAA);
+impl Mbc for Mbc2 {
+    fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..0x4000 => {
+                self.rom_banks[0][addr as usize]
+            },
+            0x4000..0x8000 => {
+                self.rom_banks[self.rom_bank_register as usize][(addr - 0x4000) as usize]
+            },
+            0xA000..0xC000 => {
+                if self.ram_gate_register {
+                    self.ram_banks[0][(addr & 0b1111_1111) as usize]
+                } else {
+                    0
+                }
+            }
+            _ => unreachable!()
         }
-        // ...and the rest of bank 0 is zero
-        for i in 100..0x4000 {
-            assert_eq!(mbc.banks[0][i], 0);
-        }
-        // Bank 1 is entirely zeros
-        assert!(mbc.banks[1].iter().all(|&b| b == 0));
     }
 
-    #[test]
-    fn multi_bank_rom_splits_correctly() {
-        // Create 20 KiB of incrementing bytes: 0,1,2,…,19999
-        let data: Vec<u8> = (0..20_480).map(|i| (i % 256) as u8).collect();
-        let mbc = Mbc::new(&data);
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..0x4000 => {
+                if addr & 0b1_0000_0000 == 0b1_0000_0000 {
+                    self.ram_gate_register = val & 0b1010 == 0b1010
+                } else {
+                    let new_value = val & 0b1111;
+                    self.rom_bank_register = (new_value == 0) as u8 + new_value;
+                }
+            },
+            0x4000..0x8000 => { }, // do nothing 
+            0xA000..0xC000 => { 
+                if self.ram_gate_register {
+                    self.ram_banks[0][(addr & 0b1111_1111) as usize] = val;
+                }
 
-        assert_eq!(mbc.banks.len(), 2);
-        // First bank matches bytes 0..16384
-        for i in 0..0x4000 {
-            assert_eq!(mbc.banks[0][i], (i % 256) as u8);
+            },
+            _ => unreachable!()
         }
-        // Second bank matches bytes 16384..20480
-        for i in 0..(20_480 - 0x4000) {
-            assert_eq!(mbc.banks[1][i], ((i + 0x4000) % 256) as u8);
+    }
+
+    fn new(rom_image: &[u8]) -> Result<Self, String> where Self: Sized {
+        let rom_banks = map_rom_into_bank(rom_image)?;
+        Ok(Mbc2{
+            rom_banks,
+            ram_gate_register: false,
+            rom_bank_register: 0b0001,
+            ram_banks: vec![[0; RAM_BANK_SIZE]; 1],
+        })
+    }
+}
+
+pub struct RomOnly {
+    bank: [u8; ONLY_ROM_SIZE],
+}
+
+impl Default for RomOnly {
+    fn default() -> Self {
+        RomOnly {
+            bank: [0; ONLY_ROM_SIZE] 
         }
     }
 }
+
+impl Mbc for RomOnly{
+    fn new(rom_image: &[u8]) -> Result<Self, String> {
+        let mut bank = [0; ONLY_ROM_SIZE];
+        let end = min(ONLY_ROM_SIZE, rom_image.len());
+        bank[..end].copy_from_slice(&rom_image[..end]);
+        Ok(RomOnly {
+            bank
+        })
+    }
+
+    fn read(&self, addr: u16) -> u8 {
+        self.bank[addr as usize]
+    }
+
+    fn write(&mut self, addr: u16, val: u8) {
+        if (0xA000..0xC000).contains(&addr) {
+            self.bank[addr as usize] = val
+        }
+
+    }
+}
+
+#[derive(Default)]
+pub struct Mbc3 {
+    rtc_register: u8,
+    ram_timer_enable: bool,
+    rom_bank_nb: u8,
+    ram_rtc_select: u8,
+    latch_clock_data: u8,
+    latched_time_value: Option<DateTime<Local>>,
+    rom_banks: Vec<[u8; ROM_BANK_SIZE]>,
+    ram_banks: Vec<[u8; RAM_BANK_SIZE]>,
+}
+
+impl Mbc3 {
+    fn get_time_value(&self, rtc_select: &u8) -> u8 {
+        let time = if let Some(latched_time) = &self.latched_time_value {
+            latched_time.clone()
+        } else {
+            self.get_actual_time()
+        };
+
+        match rtc_select {
+            0x08 => todo!(), // where the days start from ? 
+            0x09 => todo!(), // where the days start from ? 
+            0x0A => todo!(), // where the days start from ? 
+            0x0B => todo!(), // where the days start from ? 
+            0x0C => todo!(),
+            _ => 0, // In case the rtc_select data is trash
+        }
+    }
+
+    fn get_actual_time(&self) -> DateTime<Local> {
+        Local::now()
+    }
+}
+
+impl Mbc for Mbc3 {
+    fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..0x4000 => self.rom_banks[0][addr as usize],
+            0x4000..0x8000 => self.rom_banks[self.rom_bank_nb as usize][(addr - 0x4000) as usize],
+            0xA000..0xC000 => {
+                if (0x00..0x07).contains(&self.ram_rtc_select) {
+                    self.ram_banks[self.ram_rtc_select as usize][(addr - 0xA000) as usize]
+                } else {
+                    self.get_time_value(&self.ram_rtc_select)
+                }
+            },
+            _ => unreachable!(),
+        }
+    }
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..0x2000 => self.ram_timer_enable = val == 0b1010,
+            0x2000..0x4000 => self.rom_bank_nb = (val != 0) as u8 * val + (val == 0) as u8,
+            0x4000..0x6000 => self.ram_rtc_select = val,
+            0x6000..0x8000 => {
+                if self.latch_clock_data == 0b00 && val == 0b01 {
+                    self.latched_time_value = Some(self.get_actual_time());
+                } else {
+                    self.latched_time_value = None;
+                }
+            },
+            0xA000..0xC000 => {
+                self.ram_banks[
+                    self.ram_rtc_select as usize
+                ][
+                    (addr - 0xA000) as usize
+                ] = val;
+            }
+            _ => unreachable!(),
+        }
+        
+    }
+    fn new(rom_image: &[u8]) -> Result<Self, String> where Self: Sized {
+        let rom_banks = map_rom_into_bank(rom_image)?;
+        let ram_banks = map_ram_banks(rom_image)?;
+
+        Ok(
+            Mbc3 {
+                rom_banks,
+                ram_banks,
+                rtc_register: 0,
+                ram_timer_enable: false,
+                rom_bank_nb: 0,
+                ram_rtc_select: 0,
+                latched_time_value: None,
+                latch_clock_data: 0,
+
+            }
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct Mbc5 {
+    ram_gate_enable: bool,
+    rom_bank_register: u16,
+    ram_bank_register: u8,
+    ramble: bool,
+    rom_banks: Vec<[u8; ROM_BANK_SIZE]>,
+    ram_banks: Vec<[u8; RAM_BANK_SIZE]>,
+    
+}
+
+impl Mbc for Mbc5 {
+    fn new(rom_image: &[u8]) -> Result<Self, String> where Self: Sized {
+        let rom_banks = map_rom_into_bank(rom_image)?;
+        let ram_banks = map_ram_banks(rom_image)?;
+
+        Ok(
+            Mbc5 {
+                rom_banks,
+                ram_banks,
+                ram_gate_enable: false,
+                rom_bank_register: 0,
+                ram_bank_register: 0,
+                ramble: false,
+            }
+        )
+    }
+    fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..0x4000 => self.rom_banks[0][addr as usize],
+            0x4000..0x8000 => {
+                self.rom_banks[
+                    (self.rom_bank_register - 0x4000) as usize
+                ][
+                    (addr  - 0x4000) as usize
+                ]
+            },
+            0xA000..0xC000 => {
+                self.ram_banks[
+                    self.ram_bank_register as usize
+                ][
+                    (addr - 0xA000) as usize
+                ]
+            },
+            _ => unreachable!(),
+        }
+    }
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..0x2000 => self.ram_gate_enable = val == 0b0000_1010,
+            0x2000..0x3000 => self.rom_bank_register = self.rom_bank_register & 0x100 + val as u16,
+            0x3000..0x4000 => self.rom_bank_register = self.rom_bank_register & 0x0FF + val as u16 & 0x01 * 0x100,
+            0x4000..0x6000 => {
+                self.ram_bank_register = val & 0x0F;
+                self.ramble = (val & 0x10) != 0;
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+

--- a/src/mmu/oam.rs
+++ b/src/mmu/oam.rs
@@ -68,7 +68,7 @@ impl Oam {
 			1 => self.sprites[sprite].x = val,
 			2 => self.sprites[sprite].tile = val,
 			3 => self.sprites[sprite].attributes = val,
-			_ => return,
+			_ => (),
 		}
 	}
 }


### PR DESCRIPTION
La PR viens permettre a la gameboy d'etre une classe template contenant une Mbc. 

A ce jour on gere la RomOnly et la MBC1

La rom only est un mapping 1 pour 1 de la memoire sur la zone memoire 0x0000 -> 0x7FFF

Le MBC1 permet de mapper un plus grand espace memoire en decoupant la rom en banque de 0x4000 octets

En fonction des registres du mbc1 et de la zone memoire cible on cherche dans une banque ou une autre. 

Je me suis appuye majoritairement sur cette documentation : https://gekkio.fi/files/gb-docs/gbctr.pdf