### PR TITLE
feat: [Pixel FIFO] Pixel Fetcher

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -180,7 +180,6 @@ impl<T: Mbc> Default for Mmu<T> {
     }
 }
 
-// In mmu.rs
 #[cfg(test)]
 mod tests {
     use crate::mmu::mbc::RomOnly;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -129,7 +129,16 @@ impl<T: Mbc> Ppu<T> {
         }
     }
 
+
     pub fn get_pixel_color_index(&self, tile_data: [u8; 16], x: usize, y: usize) -> u8 {
+        /*
+            Every tile is 8x8 pixels, 2 bits/pixels
+            Every line is 2 bytes:
+                - low weight bit (LSB)
+                - heavy weight bit (MSB)
+            The final pixel is (MSB << 1) | LSB
+        */
+
         let pixel_x = x % 8;
         let pixel_y = y % 8;
 
@@ -140,8 +149,6 @@ impl<T: Mbc> Ppu<T> {
 
         let lsb_bit = (lsb_byte >> bit_index) & 1;
         let msb_bit = (msb_byte >> bit_index) & 1;
-
-        
 
         (msb_bit << 1) | lsb_bit
     }
@@ -179,6 +186,13 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn get_tile_address(&self, y: usize, x: usize, use_window: bool) -> u16 {
+        /*
+            The Game Boy has 2 tilemaps (BG and Windows)
+            and 2 addressing modes for tiles:
+                - 0x8000 (unsigned index)
+                - 0x8800/0x9000 (signed index)
+        */
+
         let tilemap_base: std::ops::Range<u16> = if use_window {
             self.lcd_control.window_tile_map_area()
         } else {
@@ -192,7 +206,9 @@ impl<T: Mbc> Ppu<T> {
             .unwrap()
             .read_byte(tilemap_base.start + offset);
         match self.lcd_control.bg_window_tile_data_area() {
+            // Unsigned mode: simple multiplication
             lcd_control::TILE_DATA_1 => 0x8000 + (tile_number as u16) * 16,
+            // Signed mode: tile_number is interpreted as i8 ([-128;127]), base = 0x9000
             lcd_control::TILE_DATA_0 => {
                 let base = 0x9000u16;
                 let offset = (tile_number as i8) as i16 * 16;
@@ -203,6 +219,8 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn oam_search(&mut self) {
+        // Select max 10 visible sprites on the scanline
+
         let height:u8 = if self.lcd_control.is_obj_size_8x16() {
             16
         } else {
@@ -231,16 +249,26 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn render_background(&self) -> Vec<Pixel> {
+        /*
+            Generate one complete scanline (160 pixels) by applying:
+                - scroll (SCX/SCY)
+                - window (WX/WY)
+                - wrapping (256x256)
+         */
+
         let mut pixels = Vec::new();
         let ly = self.ly as usize; // line to render
         let default_color = self.apply_background_palette(0);
 
         for x in 0..WIN_SIZE_X {
+            // If BG is disabled, color 0 everywhere
             if !self.lcd_control.is_bg_window_enabled() {
                 pixels.push(Pixel::new(default_color, false, 0));
                 continue;
             }
 
+            // Hardware condition to enable the window
+            // WX is shifted by 7 pixels
             let use_window = self.lcd_control.is_window_enabled()
                 && (ly >= self.wy as usize)
                 && (x + 7 >= self.wx as usize);
@@ -250,6 +278,7 @@ impl<T: Mbc> Ppu<T> {
                 let win_y = self.wly as usize;
                 (win_x % 256, win_y % 256)
             } else {
+                // coordinates with scrool (wrap 256)
                 (
                     (x + self.scx as usize) % 256,
                     (ly + self.scy as usize) % 256,
@@ -291,6 +320,8 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn get_right_pixel(&self, old_pixel: &Pixel, color: Color, priority: bool) -> Option<Pixel> {
+        // Deal with sprite/background priority
+
         if old_pixel.get_is_sprite() {
             return None
         }
@@ -332,16 +363,28 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn render_sprites(&self, mut pixels: Vec<Pixel>) -> Vec<Pixel> {
+        /*
+            Apply sprites above background
+            respect:
+                - priority
+                - flip X/Y
+                - palettes
+                - transparency
+        */
+
         let height: u8 = if self.lcd_control.is_obj_size_8x16() { 16 } else { 8 };
 
+        // sort by X then OAM order (hardware behavior)
         let sorted_sprites = self.sort_sprites_by_x();
-       for sprite in sorted_sprites {
+
+        for sprite in sorted_sprites {
             if !self.lcd_control.is_obj_enabled() {
                 continue;
             }
 
             let (priority, y_flip, x_flip, palette_attribute) = self.extract_attributes(sprite.attributes);
 
+            // sprite coordinates are shifted: Y - 16, X - 8
             let sprite_top: i16 = sprite.y as i16 - 16;
             let sprite_line = (self.ly as i16 - sprite_top) as usize;
 
@@ -357,7 +400,8 @@ impl<T: Mbc> Ppu<T> {
 
                 let actual_pixel_x = if x_flip { 7 - pixel_x } else { pixel_x };
                 let color_index = self.get_pixel_color_index(tile, actual_pixel_x as usize, actual_sprite_line % 8); // % 8 to handle 8x16
-                    
+
+                // 0 = transparency for sprites 
                 if color_index == 0 { continue; }
                     
                 let color = self.apply_sprite_palette(color_index, palette_attribute);
@@ -402,6 +446,8 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn mode_hblank(&mut self) -> bool {
+        // End of scanline -> next one after 456 dots
+
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
 
@@ -459,6 +505,12 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn check_lyc_equals_ly(&mut self) {
+        /*
+            LYC == LY is an hardware condition:
+                - update a flag in STAT
+                - can trigger a LCD STAT interrupt
+            It's used by many games to synchronize with scanline
+        */
         let lyc_match = self.ly == self.lyc;
         self.lcd_status.set_lyc_equals_ly(lyc_match);
         
@@ -473,15 +525,22 @@ impl<T: Mbc> Ppu<T> {
         self.scx = self.bus.read().unwrap().read_byte(SCX_ADDR);
         self.wy = self.bus.read().unwrap().read_byte(WY_ADDR);
         self.wx = self.bus.read().unwrap().read_byte(WX_ADDR);
+
+        // LCDC control the whole PPU's behavior
         self.lcd_control
             .update_from_byte(self.bus.read().unwrap().read_byte(LCD_CONTROL_ADDR));
+        
+        // STAT is an hybrid register, some bits are controlled by PPU and other by CPU
 
+        // Write internal state in memory
         let stat_byte = self.lcd_status.struct_to_byte();
         self.bus.write().unwrap().write_byte(STAT_ADDR, stat_byte);
 
+        // Read state from memory to get the modifications made by CPU
         let stat_from_mmu = self.bus.read().unwrap().read_byte(STAT_ADDR);
         self.lcd_status.update_from_byte(stat_from_mmu);
 
+        // Current line
         self.bus.write().unwrap().write_byte(LY_ADDR, self.ly);
     }
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -6,8 +6,10 @@ mod lcd_control;
 mod lcd_status;
 mod pixel;
 mod pixel_fifo;
+mod pixel_fetcher;
 
 use std::sync::Mutex;
+use std::sync::{Arc, RwLock};
 
 use crate::mmu::mbc::Mbc;
 use crate::mmu::MemoryRegion;
@@ -20,7 +22,7 @@ use crate::ppu::lcd_status::LcdStatus;
 use crate::ppu::lcd_status::PpuMode;
 use crate::ppu::pixel::Pixel;
 use crate::ppu::pixel_fifo::PixelFifo;
-use std::sync::{Arc, RwLock};
+use crate::ppu::pixel_fetcher::PixelFetcher;
 
 pub const WIN_SIZE_X: usize = 160; // Window size in X direction
 pub const WIN_SIZE_Y: usize = 144; // Window size in Y direction
@@ -57,6 +59,7 @@ pub struct Ppu<T: Mbc> {
     ly: u8,
     lyc: u8,
     x: usize,
+    fetcher: PixelFetcher,
     bg_fifo: PixelFifo, // Background pixel FIFO
     visible_sprites: [Option<Sprite>; 10],
     pub dots: u32,
@@ -76,6 +79,7 @@ impl<T: Mbc> Ppu<T> {
             ly: 0x00,
             lyc: 0x00,
             x: 0,
+            fetcher: PixelFetcher::default(),
             bg_fifo: PixelFifo::default(),
             visible_sprites: [None; 10],
             dots: 0,

--- a/src/ppu/pixel.rs
+++ b/src/ppu/pixel.rs
@@ -3,7 +3,7 @@
 
 use crate::ppu::colors_palette::Color;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Pixel {
     color: Color,
     is_sprite: bool,

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -1,0 +1,21 @@
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum FetcherState {
+    #[default]
+    GetTileId = 0,
+    GetLowData = 1,
+    GetHighData = 2,
+    PushPixel = 3,
+}
+
+#[derive(Default)]
+pub struct PixelFetcher {
+    fetcher_state: FetcherState,
+    tile_id: u8,
+    tile_data_low: u8,
+    tile_data_high: u8,
+    dot_counter: u32,
+    position_counter: u8,
+}

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -193,3 +193,164 @@ impl PixelFetcher {
         Some(tile_pixels)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mmu::Mmu;
+    use crate::mmu::mbc::RomOnly;
+    use crate::ppu::pixel_fifo::PixelFifo;
+    use crate::ppu::lcd_control::LcdControl;
+
+    use std::sync::{Arc, RwLock};
+
+    fn setup_bus() -> Arc<RwLock<Mmu<RomOnly>>> {
+        Arc::new(RwLock::new(
+            Mmu::<RomOnly>::new(&[]).unwrap()
+        ))
+    }
+
+    fn write(bus: &Arc<RwLock<Mmu<RomOnly>>>, addr: u16, val: u8) {
+        bus.write().unwrap().write_byte(addr, val);
+    }
+
+    fn setup_fetcher() -> (PixelFetcher, PixelFifo, LcdControl) {
+        (
+            PixelFetcher::default(),
+            PixelFifo::new(),
+            LcdControl::default(),
+        )
+    }
+
+    #[test]
+    fn test_fifo_already_full() {
+        let (mut fetcher, mut fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
+
+        for _ in 0..8 {
+            fifo.push(Pixel::default());
+        }
+
+        fetcher.fetcher_state = FetcherState::PushPixel;
+
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+
+        assert!(result.is_none(), "Should not push when FIFO is not empty");
+        assert_eq!(fetcher.fetcher_x, 0, "fetcher_x should not increment if the push wasn't done");
+    }
+
+    #[test]
+    fn test_states_switch_in_right_order_and_timing() {
+        let (mut fetcher, mut fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
+
+        fetcher.dot_counter += 1;
+
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
+        fetcher.dot_counter += 1;
+
+        for _ in 0..8 {
+            fifo.push(Pixel::default());
+        }
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetHighData);        
+        fetcher.dot_counter += 1;
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::Sleep);        
+        fetcher.dot_counter += 1;
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::PushPixel);        
+        fetcher.dot_counter += 1;
+
+        while !fifo.is_empty() {
+            fifo.pop();
+        }
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
+    }
+    
+    #[test]
+    fn test_tick_pair_fifo_full_at_gethighdata_empty_at_pushpixel() {
+        let (mut fetcher, mut fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
+
+        fetcher.fetcher_state = FetcherState::GetHighData;
+        fetcher.dot_counter = 1;
+
+        for _ in 0..8 {
+            fifo.push(Pixel::default());
+        }
+
+        let res1 = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert!(res1.is_none());
+        assert_eq!(fetcher.fetcher_state, FetcherState::Sleep);
+
+        fetcher.dot_counter += 1;
+
+        let res2 = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert!(res2.is_none());
+        assert_eq!(fetcher.fetcher_state, FetcherState::PushPixel);
+
+        while !fifo.is_empty() {
+            fifo.pop();
+        }
+
+        let res3 = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert!(res3.is_some(), "Should push tile when FIFO becomes empty");
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
+        assert_eq!(fetcher.fetcher_x, 1, "fetcher_x should increment after push");
+    }
+
+    #[test]
+    fn test_tick_odd_and_fifo_empty() {
+        let (mut fetcher, fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
+
+        fetcher.fetcher_state = FetcherState::PushPixel;
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+
+        assert!(result.is_some(), "Should push tile when tick is odd and FIFO is empty");
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
+        assert_eq!(fetcher.fetcher_x, 1, "fetcher_x should increment after push");
+    }
+
+    #[test]
+    fn test_opportunistic_push_in_get_high_data() {
+        let (mut fetcher, fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
+
+        fetcher.dot_counter += 1;
+
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
+        fetcher.dot_counter += 1;
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetHighData);        
+        fetcher.dot_counter += 1;
+
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
+        assert!(result.is_some());
+        assert_eq!(fetcher.fetcher_x, 1);
+    }
+
+
+    // fn test_scx_misalignment_bug() {
+    //     let (mut fetcher, mut fifo, lcd) = setup_fetcher();
+    //     let bus = setup_bus();
+    // }
+
+    // fn test_wx_glitch() {
+    //     let (mut fetcher, mut fifo, lcd) = setup_fetcher();
+    //     let bus = setup_bus();
+    // }
+}

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -5,8 +5,10 @@ use crate::mmu::Mmu;
 use crate::mmu::mbc::Mbc;
 use crate::ppu::lcd_control::LcdControl;
 use crate::ppu::pixel::Pixel;
+use crate::ppu::colors_palette::Color;
 use std::sync::{Arc, RwLock};
 
+const BGP_ADDR: u16 = 0xFF47; // Background Palette
 const TILE_DATA_1_START: u16 = 0x8000;
 const TILE_DATA_0_START: u16 = 0x8800;
 
@@ -58,7 +60,14 @@ impl PixelFetcher {
 
                     return None
                 },
-                FetcherState::PushPixel => return None,
+                FetcherState::PushPixel => {
+                    let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
+
+                    self.fetcher_x += 1;
+                    self.fetcher_state = FetcherState::GetTileId;
+
+                    tile
+                },
             }
         } else {
             None
@@ -142,5 +151,33 @@ impl PixelFetcher {
         } else {
             unreachable!()
         }
+    }
+
+    fn apply_background_palette<T: Mbc>(&self, bus: &Arc<RwLock<Mmu<T>>>, color_index: u8) -> Color {
+        let palette = bus.read().unwrap().read_byte(BGP_ADDR);
+
+        let index = (palette >> (color_index * 2)) & 0b11;
+
+        Color::from_index(index)
+    }
+
+    fn push_pixel<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>) -> Option<[Pixel; 8]> {
+        let mut tile_pixels = [Pixel::default(); 8];
+
+        for i in 0..8 {
+            let bit_index = 7 - i;
+
+            let low_weight_bit = (self.tile_data_low >> bit_index) & 1;
+            let high_weight_bit = (self.tile_data_high >> bit_index) & 1;
+
+            let color_index = (high_weight_bit << 1) | low_weight_bit;
+            let bgp = self.apply_background_palette(bus, color_index);
+
+            let pixel = Pixel::new(bgp, false, color_index);
+            
+            tile_pixels[i as usize] = pixel;
+        }
+
+        Some(tile_pixels)
     }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -1,13 +1,19 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+use crate::mmu::Mmu;
+use crate::mmu::mbc::Mbc;
+use crate::ppu::pixel::Pixel;
+use std::sync::{Arc, RwLock};
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum FetcherState {
     #[default]
     GetTileId = 0,
     GetLowData = 1,
     GetHighData = 2,
-    PushPixel = 3,
+    Sleep = 3,
+    PushPixel = 4,
 }
 
 #[derive(Default)]
@@ -18,4 +24,20 @@ pub struct PixelFetcher {
     tile_data_high: u8,
     dot_counter: u32,
     position_counter: u8,
+}
+
+impl PixelFetcher {
+    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, use_window: bool) -> Option<[Pixel; 8]> {
+        if self.dot_counter % 2 == 0 {
+            match self.fetcher_state {
+                FetcherState::GetTileId => return None,
+                FetcherState::GetLowData => return None,
+                FetcherState::GetHighData => return None,
+                FetcherState::Sleep => return None,
+                FetcherState::PushPixel => return None,
+            }
+        } else {
+            None
+        }
+    }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -7,6 +7,9 @@ use crate::ppu::lcd_control::LcdControl;
 use crate::ppu::pixel::Pixel;
 use std::sync::{Arc, RwLock};
 
+const TILE_DATA_1_START: u16 = 0x8000;
+const TILE_DATA_0_START: u16 = 0x8800;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum FetcherState {
     #[default]
@@ -39,10 +42,22 @@ impl PixelFetcher {
                     return None
                 },
                 FetcherState::GetLowData => {
+                    self.tile_data_low = self.get_tile_data_low(bus, ly, scy, lcd_control);
+                    self.fetcher_state = FetcherState::GetHighData;
+
                     return None
                 },
-                FetcherState::GetHighData => return None,
-                FetcherState::Sleep => return None,
+                FetcherState::GetHighData => {
+                    self.tile_data_high = self.get_tile_data_high(bus, ly, scy, lcd_control);
+                    self.fetcher_state = FetcherState::Sleep;
+
+                    return None
+                },
+                FetcherState::Sleep => {
+                    self.fetcher_state = FetcherState::PushPixel;
+
+                    return None
+                },
                 FetcherState::PushPixel => return None,
             }
         } else {
@@ -57,7 +72,7 @@ impl PixelFetcher {
             lcd_control.bg_tile_map_area()
         };
 
-        let x = ((scx / 8) as u16 + self.fetcher_x as u16) & 0x1F; // mask to keep the 5 lowest bits
+        let x: u16 = ((scx / 8) as u16 + self.fetcher_x as u16) & 0x1F; // mask to keep the 5 lowest bits
         let y: u16 = ((ly as u16 + scy as u16) / 8) & 0xFF;
 
         let offset = (y * 32 + x) as u16;
@@ -68,5 +83,64 @@ impl PixelFetcher {
             .read_byte(tilemap_base.start + offset);
 
         tile_number
+    }
+
+    fn get_tile_data_low<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scy: u8, lcd_control: &LcdControl) -> u8 {
+        let correct_byte = ((ly as u16 + scy as u16) % 8) * 2;
+
+        if lcd_control.bg_window_tile_data_area().start == TILE_DATA_1_START {
+            let tilemap_base = TILE_DATA_1_START + (self.tile_id as u16) * 16;
+
+            let tile_low = bus
+                .read()
+                .unwrap()
+                .read_byte(tilemap_base + correct_byte);
+
+            tile_low
+            
+        } else if lcd_control.bg_window_tile_data_area().start == TILE_DATA_0_START {
+            let base = 0x9000u16;
+            let offset = (self.tile_id as i8) as i16 * 16;
+            let tilemap_base = base.wrapping_add_signed(offset);
+
+            let tile_low = bus
+                .read()
+                .unwrap()
+                .read_byte(tilemap_base + correct_byte);
+
+            tile_low
+        } else {
+            unreachable!()
+        }
+    }
+
+
+    fn get_tile_data_high<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scy: u8, lcd_control: &LcdControl) -> u8 {
+        let correct_byte = (((ly as u16 + scy as u16) % 8) * 2) + 1;
+
+        if lcd_control.bg_window_tile_data_area().start == TILE_DATA_1_START {
+            let tilemap_base = TILE_DATA_1_START + (self.tile_id as u16) * 16;
+
+            let tile_low = bus
+                .read()
+                .unwrap()
+                .read_byte(tilemap_base + correct_byte);
+
+            tile_low
+            
+        } else if lcd_control.bg_window_tile_data_area().start == TILE_DATA_0_START {
+            let base = 0x9000u16;
+            let offset = (self.tile_id as i8) as i16 * 16;
+            let tilemap_base = base.wrapping_add_signed(offset);
+
+            let tile_low = bus
+                .read()
+                .unwrap()
+                .read_byte(tilemap_base + correct_byte);
+
+            tile_low
+        } else {
+            unreachable!()
+        }
     }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -3,6 +3,7 @@
 
 use crate::mmu::Mmu;
 use crate::mmu::mbc::Mbc;
+use crate::ppu::lcd_control::LcdControl;
 use crate::ppu::pixel::Pixel;
 use std::sync::{Arc, RwLock};
 
@@ -23,15 +24,23 @@ pub struct PixelFetcher {
     tile_data_low: u8,
     tile_data_high: u8,
     dot_counter: u32,
-    position_counter: u8,
+    fetcher_x: u8,
 }
 
 impl PixelFetcher {
-    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, use_window: bool) -> Option<[Pixel; 8]> {
+    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
+        self.dot_counter += 1;
         if self.dot_counter % 2 == 0 {
             match self.fetcher_state {
-                FetcherState::GetTileId => return None,
-                FetcherState::GetLowData => return None,
+                FetcherState::GetTileId => {
+                    self.tile_id = self.get_tile_id(bus, ly, scx, scy, lcd_control, use_window);
+                    self.fetcher_state = FetcherState::GetLowData;
+
+                    return None
+                },
+                FetcherState::GetLowData => {
+                    return None
+                },
                 FetcherState::GetHighData => return None,
                 FetcherState::Sleep => return None,
                 FetcherState::PushPixel => return None,
@@ -39,5 +48,25 @@ impl PixelFetcher {
         } else {
             None
         }
+    }
+
+    fn get_tile_id<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> u8 {
+        let tilemap_base: std::ops::Range<u16> = if use_window {
+            lcd_control.window_tile_map_area()
+        } else {
+            lcd_control.bg_tile_map_area()
+        };
+
+        let x = ((scx / 8) as u16 + self.fetcher_x as u16) & 0x1F; // mask to keep the 5 lowest bits
+        let y: u16 = ((ly as u16 + scy as u16) / 8) & 0xFF;
+
+        let offset = (y * 32 + x) as u16;
+
+        let tile_number = bus
+            .read()
+            .unwrap()
+            .read_byte(tilemap_base.start + offset);
+
+        tile_number
     }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -6,6 +6,7 @@ use crate::mmu::mbc::Mbc;
 use crate::ppu::lcd_control::LcdControl;
 use crate::ppu::pixel::Pixel;
 use crate::ppu::colors_palette::Color;
+use crate::ppu::pixel_fifo::PixelFifo;
 use std::sync::{Arc, RwLock};
 
 const BGP_ADDR: u16 = 0xFF47; // Background Palette
@@ -33,9 +34,17 @@ pub struct PixelFetcher {
 }
 
 impl PixelFetcher {
-    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
+    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, fifo: &PixelFifo, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
         self.dot_counter += 1;
-        if self.dot_counter % 2 == 0 {
+
+        if self.fetcher_state == FetcherState::PushPixel && fifo.is_empty() {
+            let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
+
+            self.fetcher_x += 1;
+            self.fetcher_state = FetcherState::GetTileId;
+
+            tile
+        } else if self.dot_counter % 2 == 0 {
             match self.fetcher_state {
                 FetcherState::GetTileId => {
                     self.tile_id = self.get_tile_id(bus, ly, scx, scy, lcd_control, use_window);
@@ -60,14 +69,7 @@ impl PixelFetcher {
 
                     return None
                 },
-                FetcherState::PushPixel => {
-                    let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
-
-                    self.fetcher_x += 1;
-                    self.fetcher_state = FetcherState::GetTileId;
-
-                    tile
-                },
+                FetcherState::PushPixel => { return None; },
             }
         } else {
             None

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -60,9 +60,19 @@ impl PixelFetcher {
                 },
                 FetcherState::GetHighData => {
                     self.tile_data_high = self.get_tile_data_high(bus, ly, scy, lcd_control);
-                    self.fetcher_state = FetcherState::Sleep;
 
-                    return None
+                    if fifo.is_empty() {
+                        let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
+
+                        self.fetcher_x += 1;
+                        self.fetcher_state = FetcherState::GetTileId;
+
+                        tile
+                    } else {
+                        self.fetcher_state = FetcherState::Sleep;
+
+                        return None
+                    }
                 },
                 FetcherState::Sleep => {
                     self.fetcher_state = FetcherState::PushPixel;

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -343,11 +343,25 @@ mod tests {
         assert_eq!(fetcher.fetcher_x, 1);
     }
 
+    #[test]
+    fn test_window_is_activated_mid_cycle() {
+        let (mut fetcher, fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
 
-    // fn test_scx_misalignment_bug() {
-    //     let (mut fetcher, mut fifo, lcd) = setup_fetcher();
-    //     let bus = setup_bus();
-    // }
+        fetcher.dot_counter += 1;
+
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
+
+        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
+        fetcher.dot_counter += 1;
+
+        // use_window become true, the cycle is reset
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, true);
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
+        assert!(result.is_none(), "The cycle should be reset and not push anything.");
+    }
+
 
     // fn test_wx_glitch() {
     //     let (mut fetcher, mut fifo, lcd) = setup_fetcher();

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -29,13 +29,18 @@ pub struct PixelFetcher {
     tile_id: u8,
     tile_data_low: u8,
     tile_data_high: u8,
-    dot_counter: u32,
     fetcher_x: u8,
+    dot_counter: u32,
+    use_window: bool,
 }
 
 impl PixelFetcher {
     pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, fifo: &PixelFifo, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
         self.dot_counter += 1;
+
+        if self.reset_if_window(use_window) {
+           return None;
+        }
 
         if self.fetcher_state == FetcherState::PushPixel && fifo.is_empty() {
             let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
@@ -84,6 +89,21 @@ impl PixelFetcher {
         } else {
             None
         }
+    }
+
+    fn reset_if_window(&mut self, use_window: bool) -> bool {
+        if !self.use_window && use_window {
+            self.fetcher_state = FetcherState::GetTileId;
+            self.fetcher_x = 0;
+
+            self.use_window = use_window;
+
+            return true;
+        }
+
+        self.use_window = use_window;
+
+        false
     }
 
     fn get_tile_id<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> u8 {
@@ -356,15 +376,12 @@ mod tests {
         assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
         fetcher.dot_counter += 1;
 
+        fetcher.fetcher_x = 4;
+
         // use_window become true, the cycle is reset
         let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, true);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
         assert!(result.is_none(), "The cycle should be reset and not push anything.");
+        assert_eq!(fetcher.fetcher_x, 0, "fetcher_x should be reset to 0.");
     }
-
-
-    // fn test_wx_glitch() {
-    //     let (mut fetcher, mut fifo, lcd) = setup_fetcher();
-    //     let bus = setup_bus();
-    // }
 }


### PR DESCRIPTION
Implémentation de la structure et des fonctions du Pixel Fetcher. IL N'EST PAS ENCORE BRANCHÉ AU PPU.
Néanmoins toutes les fonctions ont été testées et validées par des tests unitaires.

Pandocs:
"""
[FIFO Pixel Fetcher](https://gbdev.io/pandocs/pixel_fifo.html#fifo-pixel-fetcher)

The fetcher fetches a row of 8 background or window pixels and queues them up to be mixed with object pixels. The pixel fetcher has 5 steps. The first four steps take 2 dots each and the fifth step is attempted every dot until it succeeds. The order of the steps are as follows:

   - Get tile
   - Get tile data low
   - Get tile data high
   - Sleep
   - Push
""" 
  
Concrètement, le Pixel Fetcher est ce qui push le pixel dans le fifo du background, huit par huit, pour que le fifo les push sur l'écran.

Il y a plusieurs cas un peu particuliers qu'il fallait prendre en compte, notamment:
- Bien que chaque cycle dure deux dots, *Push* tente de pousser tous les dots si le fifo est vide.
- Si fifo est vide, *Get tile data high* va essayer de pousser sans attendre *Push*. Parce que pourquoi pas.
- Si la fenêtre est activée mid-scanline, le scan et le cycle sont reset.