### PR TITLE
122 [Pixel Fifo] BG FIFO implemented

### DIFF
--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -16,7 +16,6 @@ const WIN_SIZE_X: usize = 160; // Window size in X direction
 const WIN_SIZE_Y: usize = 144; // Window size in Y direction
 const VBLANK_SIZE: usize = 10; // VBlank size in lines
 
-#[derive(Default)]
 pub struct GameBoy<T: Mbc> {
     pub cpu: Cpu<T>,
     pub ppu: Ppu<T>,

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -450,7 +450,9 @@ impl<T: Mbc> Ppu<T> {
                 && (self.ly as usize >= self.wy as usize)
                 && (self.x + 7 >= self.wx as usize);    
 
+            // check if window is activated in the middle of scanline
             if !self.use_window && use_window {
+                self.fetcher.reset();
                 self.bg_fifo.clear();
                 self.use_window = use_window;
             }
@@ -524,7 +526,7 @@ impl<T: Mbc> Ppu<T> {
             self.bg_color_indices = [0; 160];
             self.x = 0;
             self.bg_fifo.clear();
-            self.fetcher.reset_at_new_line();
+            self.fetcher.reset();
             self.pixels_to_discard = self.scx % 8;
             self.use_window = false;
 
@@ -557,7 +559,7 @@ impl<T: Mbc> Ppu<T> {
                 self.bg_color_indices = [0; 160];
                 self.x = 0;
                 self.bg_fifo.clear();
-                self.fetcher.reset_at_new_line();
+                self.fetcher.reset();
                 self.pixels_to_discard = self.scx % 8;
                 self.use_window = false;
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -48,6 +48,7 @@ const SCANLINE_DOTS: u32 = 456; // always 456
 
 pub struct Ppu<T: Mbc> {
     pub bus: Arc<RwLock<Mmu<T>>>,
+    pub dots: u32,
     lcd_control: LcdControl,
     lcd_status: LcdStatus, // LCD Status register
     scx: u8,               // Scroll X
@@ -61,7 +62,7 @@ pub struct Ppu<T: Mbc> {
     fetcher: PixelFetcher,
     bg_fifo: PixelFifo, // Background pixel FIFO
     visible_sprites: [Option<Sprite>; 10],
-    pub dots: u32,
+    pixels_to_discard: u8, // Required in order to prevent the SCX misalignment bug
     bg_color_indices: [u8; 160], // tmp until FIFO OBJ
 }
 
@@ -69,6 +70,7 @@ impl<T: Mbc> Ppu<T> {
     pub fn new(bus: Arc<RwLock<Mmu<T>>>) -> Self {
         Ppu {
             bus,
+            dots: 0,
             lcd_control: LcdControl::default(),
             lcd_status: LcdStatus::new(),
             scx: 0x00,
@@ -82,7 +84,7 @@ impl<T: Mbc> Ppu<T> {
             fetcher: PixelFetcher::default(),
             bg_fifo: PixelFifo::default(),
             visible_sprites: [None; 10],
-            dots: 0,
+            pixels_to_discard: 0,
             bg_color_indices: [0u8; 160],
         }
     }
@@ -437,6 +439,11 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
+    // TODO SCX misalignment
+    // TODO WX glitch
+    // TODO push color 0 when BG disabled
+    // TODO Reset at the beginning of VBlank
+    // TODO Window activation mid-scanline -> empty fifo
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         if self.ly < WIN_SIZE_Y as u8 {
             // let mut pixels = self.render_background();
@@ -455,15 +462,19 @@ impl<T: Mbc> Ppu<T> {
 
             {
                 if let Some(current_pixel) = self.bg_fifo.pop() {
-                    self.bg_color_indices[self.x] = current_pixel.get_color_index();
+                    if self.pixels_to_discard > 0 {
+                        self.pixels_to_discard -= 1;
+                    } else {
+                        self.bg_color_indices[self.x] = current_pixel.get_color_index();
 
-                    let mut frame = image.lock().unwrap();
-                    let ly = self.ly as usize;
+                        let mut frame = image.lock().unwrap();
+                        let ly = self.ly as usize;
 
-                    let offset = (ly * WIN_SIZE_X + self.x) * 3; // * 3 for each pixels (3 bytes (RGB))
-                    self.set_pixel_color(&mut frame, offset, *current_pixel.get_color());
+                        let offset = (ly * WIN_SIZE_X + self.x) * 3; // * 3 for each pixels (3 bytes (RGB))
+                        self.set_pixel_color(&mut frame, offset, *current_pixel.get_color());
 
-                    self.x += 1;
+                        self.x += 1;
+                    }
                 }
 
             }
@@ -496,7 +507,9 @@ impl<T: Mbc> Ppu<T> {
             // reset for newline
             self.bg_color_indices = [0; 160];
             self.x = 0;
+            self.bg_fifo.clear();
             self.fetcher.reset_at_new_line();
+            self.pixels_to_discard = self.scx % 8;
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -368,8 +368,11 @@ impl<T: Mbc> Ppu<T> {
         sprites.into_iter().map(| (_, s) | s).collect()
     }
 
-    fn render_sprites(&self, image: &mut Arc<Mutex<Vec<u8>>>) -> &mut Arc<Mutex<Vec<u8>>> {
+    fn render_sprites(&self, image: &mut Arc<Mutex<Vec<u8>>>, bg_color_indices: &[u8; 160]) {
         /*
+            TODO Transition modification until the FIFO OBJ is implemented. Right now the modifications
+            should make the function works while we test the FIFO background
+
             Apply sprites above background
             respect:
                 - priority
@@ -412,12 +415,14 @@ impl<T: Mbc> Ppu<T> {
                     
                 let color = self.apply_sprite_palette(color_index, palette_attribute);
 
-                if let Some(new_pixel) = self.get_right_pixel(&pixels[screen_x as usize], color, priority) {
-                    pixels[screen_x as usize] = new_pixel;
+                if let Some(new_pixel) = self.get_right_pixel(bg_color_indices[screen_x as usize], color, priority) {
+                    let offset = (self.ly as usize * WIN_SIZE_X + screen_x as usize) * 3;
+                    let mut frame = image.lock().unwrap();
+
+                    self.set_pixel_color(&mut frame, offset, new_pixel);
                 }
             }
         }
-        image
     }
 
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -46,7 +46,6 @@ const PIXEL_TRANSFER_DOTS: u32 = 172; // can change between 172 and 289, to hand
 const HBLANK_DOTS: u32 = 204; // can change between 87 and 204, to handle later
 const SCANLINE_DOTS: u32 = 456; // always 456
 
-#[derive(Default)]
 pub struct Ppu<T: Mbc> {
     pub bus: Arc<RwLock<Mmu<T>>>,
     lcd_control: LcdControl,
@@ -84,7 +83,7 @@ impl<T: Mbc> Ppu<T> {
             bg_fifo: PixelFifo::default(),
             visible_sprites: [None; 10],
             dots: 0,
-            bg_color_indices: [0; 160],
+            bg_color_indices: [0u8; 160],
         }
     }
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -440,16 +440,33 @@ impl<T: Mbc> Ppu<T> {
 
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         if self.ly < WIN_SIZE_Y as u8 {
-            let mut pixels = self.render_background();
+            // let mut pixels = self.render_background();
+
+            let use_window = self.lcd_control.is_window_enabled()
+                && (self.ly as usize >= self.wy as usize)
+                && (self.x + 7 >= self.wx as usize);    
+
+            let tile_pixels = self.fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, &self.lcd_control, use_window);
+            
+            if let Some(pixels) = tile_pixels {
+                for pixel in pixels {
+                    self.bg_fifo.push(pixel);
+                }
+            }
 
             {
-                let mut frame = image.lock().unwrap();
-                let ly = self.ly as usize;
+                if let Some(current_pixel) = self.bg_fifo.pop() {
+                    self.bg_color_indices[self.x] = current_pixel.get_color_index();
 
-                for (x, p) in pixels.into_iter().enumerate() {
-                    let offset = (ly * WIN_SIZE_X + x) * 3; // * 3 for each pixels (3 bytes (RGB))
-                    self.set_pixel_color(&mut frame, offset, *p.get_color());
+                    let mut frame = image.lock().unwrap();
+                    let ly = self.ly as usize;
+
+                    let offset = (ly * WIN_SIZE_X + self.x) * 3; // * 3 for each pixels (3 bytes (RGB))
+                    self.set_pixel_color(&mut frame, offset, *current_pixel.get_color());
+
+                    self.x += 1;
                 }
+
             }
         }
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -460,6 +460,8 @@ impl<T: Mbc> Ppu<T> {
 
                 self.use_window = use_window;
                 self.wx_at_window_start = self.wx;
+
+                self.pixels_to_discard = 0;
             }
 
             if self.use_window && self.wx != self.wx_at_window_start

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -479,6 +479,8 @@ impl<T: Mbc> Ppu<T> {
 
             // reset for newline
             self.bg_color_indices = [0; 160];
+            self.x = 0;
+            self.fetcher.reset_at_new_line();
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -439,9 +439,7 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
-    // TODO SCX misalignment
     // TODO WX glitch
-    // TODO push color 0 when BG disabled
     // TODO Reset at the beginning of VBlank
     // TODO Window activation mid-scanline -> empty fifo
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
@@ -465,13 +463,25 @@ impl<T: Mbc> Ppu<T> {
                     if self.pixels_to_discard > 0 {
                         self.pixels_to_discard -= 1;
                     } else {
-                        self.bg_color_indices[self.x] = current_pixel.get_color_index();
+                        let color_index: u8;
+                        let color: Color;
+
+                        // If BG is disabled, color 0 everywhere
+                        if !self.lcd_control.is_bg_window_enabled() {
+                            color_index = 0;
+                            color = self.apply_background_palette(0);
+                        }
+                        else {
+                            color_index = current_pixel.get_color_index();
+                            color = *current_pixel.get_color();
+                        }
+                        self.bg_color_indices[self.x] = color_index;
 
                         let mut frame = image.lock().unwrap();
                         let ly = self.ly as usize;
 
                         let offset = (ly * WIN_SIZE_X + self.x) * 3; // * 3 for each pixels (3 bytes (RGB))
-                        self.set_pixel_color(&mut frame, offset, *current_pixel.get_color());
+                        self.set_pixel_color(&mut frame, offset, color);
 
                         self.x += 1;
                     }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -64,6 +64,8 @@ pub struct Ppu<T: Mbc> {
     visible_sprites: [Option<Sprite>; 10],
     pixels_to_discard: u8, // Required in order to prevent the SCX misalignment bug
     use_window: bool, // Required for BG FIFO in order to know if the window is activated midline
+    wx_at_window_start: u8, // Required to handle the WX hardware glitch
+    is_wx_glitch_happened: bool, // Required to handle the WX hardware glitch
     bg_color_indices: [u8; 160], // tmp until FIFO OBJ
 }
 
@@ -87,6 +89,8 @@ impl<T: Mbc> Ppu<T> {
             visible_sprites: [None; 10],
             pixels_to_discard: 0,
             use_window: false,
+            wx_at_window_start: 0x00,
+            is_wx_glitch_happened: false,
             bg_color_indices: [0u8; 160],
         }
     }
@@ -441,7 +445,6 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
-    // TODO WX glitch
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         if self.ly < WIN_SIZE_Y as u8 {
             // let mut pixels = self.render_background();
@@ -454,7 +457,18 @@ impl<T: Mbc> Ppu<T> {
             if !self.use_window && use_window {
                 self.fetcher.reset();
                 self.bg_fifo.clear();
+
                 self.use_window = use_window;
+                self.wx_at_window_start = self.wx;
+            }
+
+            if self.use_window && self.wx != self.wx_at_window_start
+                && self.x + 7 >= self.wx as usize
+                && !self.is_wx_glitch_happened {
+                    let glitched_pixel = Pixel::new(self.apply_background_palette(0), false, 0);
+
+                    self.bg_fifo.push(glitched_pixel);
+                    self.is_wx_glitch_happened = true;
             }
 
             let tile_pixels = self.fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, &self.lcd_control, use_window);
@@ -529,6 +543,7 @@ impl<T: Mbc> Ppu<T> {
             self.fetcher.reset();
             self.pixels_to_discard = self.scx % 8;
             self.use_window = false;
+            self.is_wx_glitch_happened = false;
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);
@@ -562,6 +577,7 @@ impl<T: Mbc> Ppu<T> {
                 self.fetcher.reset();
                 self.pixels_to_discard = self.scx % 8;
                 self.use_window = false;
+                self.is_wx_glitch_happened = false;
 
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
             }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -63,6 +63,7 @@ pub struct Ppu<T: Mbc> {
     bg_fifo: PixelFifo, // Background pixel FIFO
     visible_sprites: [Option<Sprite>; 10],
     pub dots: u32,
+    bg_color_indices: [u8; 160], // tmp until FIFO OBJ
 }
 
 impl<T: Mbc> Ppu<T> {
@@ -83,6 +84,7 @@ impl<T: Mbc> Ppu<T> {
             bg_fifo: PixelFifo::default(),
             visible_sprites: [None; 10],
             dots: 0,
+            bg_color_indices: [0; 160],
         }
     }
 
@@ -368,7 +370,7 @@ impl<T: Mbc> Ppu<T> {
         sprites.into_iter().map(| (_, s) | s).collect()
     }
 
-    fn render_sprites(&self, image: &mut Arc<Mutex<Vec<u8>>>, bg_color_indices: &[u8; 160]) {
+    fn render_sprites(&self, image: &mut Arc<Mutex<Vec<u8>>>) {
         /*
             TODO Transition modification until the FIFO OBJ is implemented. Right now the modifications
             should make the function works while we test the FIFO background
@@ -415,7 +417,7 @@ impl<T: Mbc> Ppu<T> {
                     
                 let color = self.apply_sprite_palette(color_index, palette_attribute);
 
-                if let Some(new_pixel) = self.get_right_pixel(bg_color_indices[screen_x as usize], color, priority) {
+                if let Some(new_pixel) = self.get_right_pixel(self.bg_color_indices[screen_x as usize], color, priority) {
                     let offset = (self.ly as usize * WIN_SIZE_X + screen_x as usize) * 3;
                     let mut frame = image.lock().unwrap();
 
@@ -439,7 +441,6 @@ impl<T: Mbc> Ppu<T> {
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         if self.ly < WIN_SIZE_Y as u8 {
             let mut pixels = self.render_background();
-            pixels = self.render_sprites(pixels);
 
             {
                 let mut frame = image.lock().unwrap();
@@ -453,6 +454,7 @@ impl<T: Mbc> Ppu<T> {
         }
 
         if self.x == 160 {
+            self.render_sprites(image);
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
         }
 
@@ -474,6 +476,9 @@ impl<T: Mbc> Ppu<T> {
             
             self.ly += 1;
             self.check_lyc_equals_ly();
+
+            // reset for newline
+            self.bg_color_indices = [0; 160];
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -63,6 +63,7 @@ pub struct Ppu<T: Mbc> {
     bg_fifo: PixelFifo, // Background pixel FIFO
     visible_sprites: [Option<Sprite>; 10],
     pixels_to_discard: u8, // Required in order to prevent the SCX misalignment bug
+    use_window: bool, // Required for BG FIFO in order to know if the window is activated midline
     bg_color_indices: [u8; 160], // tmp until FIFO OBJ
 }
 
@@ -85,6 +86,7 @@ impl<T: Mbc> Ppu<T> {
             bg_fifo: PixelFifo::default(),
             visible_sprites: [None; 10],
             pixels_to_discard: 0,
+            use_window: false,
             bg_color_indices: [0u8; 160],
         }
     }
@@ -440,8 +442,6 @@ impl<T: Mbc> Ppu<T> {
     }
 
     // TODO WX glitch
-    // TODO Reset at the beginning of VBlank
-    // TODO Window activation mid-scanline -> empty fifo
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         if self.ly < WIN_SIZE_Y as u8 {
             // let mut pixels = self.render_background();
@@ -449,6 +449,11 @@ impl<T: Mbc> Ppu<T> {
             let use_window = self.lcd_control.is_window_enabled()
                 && (self.ly as usize >= self.wy as usize)
                 && (self.x + 7 >= self.wx as usize);    
+
+            if !self.use_window && use_window {
+                self.bg_fifo.clear();
+                self.use_window = use_window;
+            }
 
             let tile_pixels = self.fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, &self.lcd_control, use_window);
             
@@ -515,11 +520,13 @@ impl<T: Mbc> Ppu<T> {
             self.check_lyc_equals_ly();
 
             // reset for newline
+            // TODO proper reset function
             self.bg_color_indices = [0; 160];
             self.x = 0;
             self.bg_fifo.clear();
             self.fetcher.reset_at_new_line();
             self.pixels_to_discard = self.scx % 8;
+            self.use_window = false;
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);
@@ -546,8 +553,13 @@ impl<T: Mbc> Ppu<T> {
 
                 self.wly = 0;
 
-                self.fetcher.reset_at_new_line();
+                // TODO proper reset function
+                self.bg_color_indices = [0; 160];
+                self.x = 0;
                 self.bg_fifo.clear();
+                self.fetcher.reset_at_new_line();
+                self.pixels_to_discard = self.scx % 8;
+                self.use_window = false;
 
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
             }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -546,6 +546,9 @@ impl<T: Mbc> Ppu<T> {
 
                 self.wly = 0;
 
+                self.fetcher.reset_at_new_line();
+                self.bg_fifo.clear();
+
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
             }
         }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -323,20 +323,22 @@ impl<T: Mbc> Ppu<T> {
         self.read_tile_data(tile_address)
     }
 
-    fn get_right_pixel(&self, old_pixel: &Pixel, color: Color, priority: bool) -> Option<Pixel> {
+    fn get_right_pixel(&self, color_index: u8, color: Color, priority: bool) -> Option<Color> {
         // Deal with sprite/background priority
+        //TODO tmp function to handle the transition between scanline rendering and FIFO.
+        // right now only fifo background is implemented. In order to keep render_sprites working
+        // we need to keep and adapt this function.
 
-        if old_pixel.get_is_sprite() {
-            return None
-        }
-
-        let color_index = old_pixel.get_color_index();
+        // if old_pixel.get_is_sprite() {
+        //     return None
+        // }
 
         if priority && color_index != 0 {
             return None
         }
 
-        Some(Pixel::new(color, true, color_index))
+        // Some(Pixel::new(color, true, color_index))
+        Some(color)
     }
 
     fn apply_sprite_palette(&self, color_index: u8, palette_attribute: bool) -> Color {
@@ -366,7 +368,7 @@ impl<T: Mbc> Ppu<T> {
         sprites.into_iter().map(| (_, s) | s).collect()
     }
 
-    fn render_sprites(&self, mut pixels: Vec<Pixel>) -> Vec<Pixel> {
+    fn render_sprites(&self, image: &mut Arc<Mutex<Vec<u8>>>) -> &mut Arc<Mutex<Vec<u8>>> {
         /*
             Apply sprites above background
             respect:
@@ -415,7 +417,7 @@ impl<T: Mbc> Ppu<T> {
                 }
             }
         }
-        pixels
+        image
     }
 
 
@@ -445,7 +447,10 @@ impl<T: Mbc> Ppu<T> {
             }
         }
 
-        self.lcd_status.update_ppu_mode(PpuMode::HBlank);
+        if self.x == 160 {
+            self.lcd_status.update_ppu_mode(PpuMode::HBlank);
+        }
+
         false
     }
 

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -350,26 +350,4 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(fetcher.fetcher_x, 1);
     }
-
-    #[test]
-    fn test_window_is_activated_mid_cycle() {
-        let (mut fetcher, fifo, lcd) = setup_fetcher();
-        let bus = setup_bus();
-
-        fetcher.dot_counter += 1;
-
-        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
-
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
-        assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
-        fetcher.dot_counter += 1;
-
-        fetcher.fetcher_x = 4;
-
-        // use_window become true, the cycle is reset
-        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, true);
-        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
-        assert!(result.is_none(), "The cycle should be reset and not push anything.");
-        assert_eq!(fetcher.fetcher_x, 0, "fetcher_x should be reset to 0.");
-    }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -38,10 +38,6 @@ impl PixelFetcher {
     pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, fifo: &PixelFifo, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
         self.dot_counter += 1;
 
-        if self.reset_if_window(use_window) {
-           return None;
-        }
-
         if self.fetcher_state == FetcherState::PushPixel && fifo.is_empty() {
             let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
 
@@ -91,27 +87,11 @@ impl PixelFetcher {
         }
     }
 
-    pub fn reset_at_new_line(&mut self) {
+    pub fn reset(&mut self) {
         self.fetcher_state = FetcherState::GetTileId;
         self.fetcher_x = 0;
         self.dot_counter = 0;
         self.use_window = false;
-    }
-
-
-    fn reset_if_window(&mut self, use_window: bool) -> bool {
-        if !self.use_window && use_window {
-            self.fetcher_state = FetcherState::GetTileId;
-            self.fetcher_x = 0;
-
-            self.use_window = use_window;
-
-            return true;
-        }
-
-        self.use_window = use_window;
-
-        false
     }
 
     fn get_tile_id<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> u8 {

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -91,6 +91,14 @@ impl PixelFetcher {
         }
     }
 
+    pub fn reset_at_new_line(&mut self) {
+        self.fetcher_state = FetcherState::GetTileId;
+        self.fetcher_x = 0;
+        self.dot_counter = 0;
+        self.use_window = false;
+    }
+
+
     fn reset_if_window(&mut self, use_window: bool) -> bool {
         if !self.use_window && use_window {
             self.fetcher_state = FetcherState::GetTileId;


### PR DESCRIPTION
Le FIFO est là ! Ou presque.
Maintenant les pixels du background sont bien implémentés pixel par pixel, dot par dot.
En revanche, on attends la fin de la ligne pour foutre tous les sprites comme avant.
J'ai dû faire des modifications temporaires pour que render_sprites fonctionne toujours. Elles seront supprimées quand le FIFO OBJ sera également implémenté.

Il y a beaucoup de bugs hardwares et cas particuliers que j'ai tenu à gérer, mais je pense que c'était une erreur avec le recul tant qu'on a pas quelque chose qui fonctionne pour la majorité du temps, vu que je ne suis de toute façon pas en mesure de vérifier si mon implémentation est correcte.

Le programme compile, le logo nintendo est toujours très joli (je suis presque sûr qu'il apparaît de façon plus fluide et un peu plus rapide) par contre la rom test graphique dmg-acid2 a complètement pétée, mais tant que le FIFO n'est pas implémenté à 100% je préfère ne pas trop y songer.