### PR TITLE
refactor: Modifie la structure Pixel pour l'adapter au fifo obj

### DIFF
--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -467,7 +467,7 @@ impl<T: Mbc> Ppu<T> {
             if self.use_window && self.wx != self.wx_at_window_start
                 && self.x + 7 >= self.wx as usize
                 && !self.is_wx_glitch_happened {
-                    let glitched_pixel = Pixel::new(self.apply_background_palette(0), false, 0);
+                    let glitched_pixel = Pixel::new_bg(self.apply_background_palette(0), 0);
 
                     self.bg_fifo.push(glitched_pixel);
                     self.is_wx_glitch_happened = true;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -276,7 +276,7 @@ impl<T: Mbc> Ppu<T> {
         for x in 0..WIN_SIZE_X {
             // If BG is disabled, color 0 everywhere
             if !self.lcd_control.is_bg_window_enabled() {
-                pixels.push(Pixel::new(default_color, false, 0));
+                pixels.push(Pixel::new_bg(default_color, 0));
                 continue;
             }
 
@@ -307,7 +307,7 @@ impl<T: Mbc> Ppu<T> {
 
             let color_index = self.get_pixel_color_index(tile, pixel_x, pixel_y);
             let color = self.apply_background_palette(color_index);
-            let pixel = Pixel::new(color, false, color_index);
+            let pixel = Pixel::new_bg(color, color_index);
             
             pixels.push(pixel);
         }

--- a/src/ppu/pixel.rs
+++ b/src/ppu/pixel.rs
@@ -8,14 +8,34 @@ pub struct Pixel {
     color: Color,
     is_sprite: bool,
     color_index: u8,
+    priority: bool,
+    oam_index: u8,
 }
 
 impl Pixel {
-    pub fn new(color: Color, is_sprite: bool, color_index: u8) -> Self {
+    pub fn new_bg(color: Color, color_index: u8) -> Self {
+        let priority = false;
+        let oam_index = 0;
+        let is_sprite = false;
+
         Pixel {
             color,
             is_sprite,
             color_index,
+            priority,
+            oam_index,
+        }
+    }
+
+    pub fn new_obj(color: Color, color_index: u8, priority: bool, oam_index: u8) -> Self {
+        let is_sprite = true;
+
+        Pixel {
+            color,
+            is_sprite,
+            color_index,
+            priority,
+            oam_index,
         }
     }
 
@@ -30,6 +50,14 @@ impl Pixel {
     pub fn get_color_index(&self) -> u8 {
         self.color_index
     }
+
+    pub fn get_priority(&self) -> bool {
+        self.priority
+    }
+
+    pub fn get_oam_index(&self) -> u8 {
+        self.oam_index
+    }
 }
 
 impl Default for Pixel {
@@ -38,6 +66,8 @@ impl Default for Pixel {
             color: Color::White,
             is_sprite: false,
             color_index: 0,
+            priority: false,
+            oam_index: 0,
         }
     }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -193,7 +193,7 @@ impl PixelFetcher {
             let color_index = (high_weight_bit << 1) | low_weight_bit;
             let bgp = self.apply_background_palette(bus, color_index);
 
-            let pixel = Pixel::new(bgp, false, color_index);
+            let pixel = Pixel::new_bg(bgp, color_index);
             
             tile_pixels[i as usize] = pixel;
         }


### PR DESCRIPTION
Pixel a maintenant 2 new selon si c'est un pixel de background ou de sprite. Dans le cas de ce dernier, on stocke la priorité et l'oam index (pour les priorités entre sprites). C'est nécessaire car ces vérifications vont se faire directement dans le fetcher.

(oam index à toujours à 0 dans get_right_pixel car c'est une fonction qui disparaîtra de toute façon dans le futur et pour le moment on ne se sert pas de cette information.)