### PR TITLE
fix: PPU specificities to clean display

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -172,6 +172,10 @@ impl<T: Mbc> Mmu<T> {
     pub fn get_oam(&self) -> &Oam {
         &self.oam
     }
+
+    pub fn get_boot_enable(&self) -> bool {
+        self.boot_enable
+    }
 }
 
 impl<T: Mbc> Default for Mmu<T> {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -469,11 +469,10 @@ impl<T: Mbc> Ppu<T> {
     fn handle_window_switch(&mut self, use_window: bool) {
         // check if window is activated in the middle of scanline
         if !self.use_window && use_window {
-            self.pixel_fetcher.reset();
+            self.pixel_fetcher.reset_for_window();
             self.bg_fifo.clear();
 
             self.wx_at_window_start = self.wx;
-
             self.pixels_to_discard = 0;
         }
 
@@ -670,7 +669,7 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
             self.x = 0;
             self.bg_fifo.clear();
             self.obj_piso.reset();
-            self.pixel_fetcher.reset();
+            self.pixel_fetcher.reset_for_scanline();
             self.pixels_to_discard = self.scx % 8;
             self.use_window = false;
             self.is_wx_glitch_happened = false;
@@ -704,7 +703,7 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
                 self.x = 0;
                 self.bg_fifo.clear();
                 self.obj_piso.reset();
-                self.pixel_fetcher.reset();
+                self.pixel_fetcher.reset_for_scanline();
                 self.pixels_to_discard = self.scx % 8;
                 self.use_window = false;
                 self.is_wx_glitch_happened = false;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -460,7 +460,6 @@ impl<T: Mbc> Ppu<T> {
             self.visible_sprites = [None; 10];
             self.oam_search();
 
-            if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
 
             self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
         }
@@ -625,8 +624,8 @@ impl<T: Mbc> Ppu<T> {
 /*
 Premier fetch BG resetté : "The first time the background fetcher completes step 3 on a scanline the status is fully reset and operation restarts at Step 1" — tu ne gères pas ce cas particulier du premier fetch.
 Délai après fetch sprite : "If there are less than 6 pixels remaining in the Background FIFO when the sprite fetch is done, the PPU will have to wait" — tu ne gères pas ce délai de 6 - REMAINING_PIXEL_COUNT.
-WY condition : "The condition WY = LY has been true at any point in the currently rendered frame" — tu vérifies ly >= wy mais pas si cette condition a déjà été vraie pendant la frame courante.
-OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pas vérifiée dans step_oam_fetcher.
+V WY condition : "The condition WY = LY has been true at any point in the currently rendered frame" — tu vérifies ly >= wy mais pas si cette condition a déjà été vraie pendant la frame courante.
+C OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pas vérifiée dans step_oam_fetcher.
 */
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
 
@@ -661,6 +660,8 @@ OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pa
 
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
+
+            if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
 
             if self.lcd_control.is_window_enabled()
                 && self.wy_equal_ly_condition_met

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -490,7 +490,6 @@ impl<T: Mbc> Ppu<T> {
     }
 
     fn push_pixel_to_screen(&mut self, frame: &mut [u8], use_window: bool) {
-
         if let Some(bg_pixel) = self.bg_fifo.pop() {
             if self.pixels_to_discard > 0 {
                 self.pixels_to_discard -= 1;
@@ -533,7 +532,6 @@ impl<T: Mbc> Ppu<T> {
             }
         }
 
-        self.handle_window_switch(use_window);
     }
 
 
@@ -633,6 +631,7 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
             if !self.fetching_sprite {
                 self.step_pixel_fetcher(use_window);
                 let mut frame = image.lock().unwrap();
+                self.handle_window_switch(use_window);
                 self.push_pixel_to_screen(&mut frame, use_window);
             }
         }
@@ -655,9 +654,8 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
             if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
 
             if self.lcd_control.is_window_enabled()
-                && self.wy_equal_ly_condition_met
+                && self.ly >= self.wy
                 && self.wx <= 166 {
-
                 self.wly += 1;
             }
             

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -532,13 +532,8 @@ impl<T: Mbc> Ppu<T> {
         };
 
         if self.fetching_sprite {
-
-
             if let Some(index) = self.current_sprite_to_fetch {
-
-
                 if let Some(sprite) = self.visible_sprites[index] {
-
                     let fetching_sprite = self.fetching_sprite;
 
                     self.fetching_sprite = !self.oam_fetcher.tick(
@@ -559,16 +554,12 @@ impl<T: Mbc> Ppu<T> {
             };
         }
         else {
-            
+            if !self.lcd_control.is_obj_enabled() { return; }
 
             for (index, sprite_opt) in self.visible_sprites.iter_mut().enumerate() {
-
-
                 if let Some(sprite) = sprite_opt {
 
-
                     if sprite.x as usize <= self.x + 8 {
-
                         let spritex = sprite.x;
                         let selfx = self.x;
 
@@ -585,7 +576,6 @@ impl<T: Mbc> Ppu<T> {
                             height,
                             self.x,
                         );
-
 
                         if !self.fetching_sprite {
                             *sprite_opt = None;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -434,8 +434,6 @@ impl<T: Mbc> Ppu<T> {
         if self.fetching_sprite {
             if let Some(index) = self.current_sprite_to_fetch {
                 if let Some(sprite) = self.visible_sprites[index] {
-                    let fetching_sprite = self.fetching_sprite;
-
                     self.fetching_sprite = !self.oam_fetcher.tick(
                         &self.bus,
                         &sprite,
@@ -465,8 +463,6 @@ impl<T: Mbc> Ppu<T> {
 
                         self.current_sprite_to_fetch = Some(index);
                         self.pixel_fetcher.reset_to_state_1();
-
-                        let fetching_sprite = self.fetching_sprite;
                         self.fetching_sprite = !self.oam_fetcher.tick(
                             &self.bus,
                             sprite,

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -466,8 +466,30 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
+    fn handle_window_switch(&mut self, use_window: bool) {
+        // check if window is activated in the middle of scanline
+        if !self.use_window && use_window {
+            self.pixel_fetcher.reset();
+            self.bg_fifo.clear();
 
-    fn push_pixel_to_screen(&mut self, frame: &mut [u8]) {
+            self.use_window = use_window;
+            self.wx_at_window_start = self.wx;
+
+            self.pixels_to_discard = 0;
+        }
+
+        // check wx glitch
+        if self.use_window && self.wx != self.wx_at_window_start
+            && self.x + 7 >= self.wx as usize
+            && !self.is_wx_glitch_happened {
+                let glitched_pixel = Pixel::new_bg(self.apply_background_palette(0),  0);
+
+                self.bg_fifo.push(glitched_pixel);
+                self.is_wx_glitch_happened = true;
+        }
+    }
+
+    fn push_pixel_to_screen(&mut self, frame: &mut [u8], use_window: bool) {
 
         if let Some(bg_pixel) = self.bg_fifo.pop() {
             if self.pixels_to_discard > 0 {
@@ -510,7 +532,10 @@ impl<T: Mbc> Ppu<T> {
                 self.x += 1;
             }
         }
+
+        self.handle_window_switch(use_window);
     }
+
 
     fn step_pixel_fetcher(&mut self, use_window: bool) {
         let tile_pixels = self.pixel_fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, &self.lcd_control, use_window);
@@ -588,28 +613,6 @@ impl<T: Mbc> Ppu<T> {
         }
     }
 
-    fn handle_window_switch(&mut self, use_window: bool) {
-        // check if window is activated in the middle of scanline
-        if !self.use_window && use_window {
-            self.pixel_fetcher.reset();
-            self.bg_fifo.clear();
-
-            self.use_window = use_window;
-            self.wx_at_window_start = self.wx;
-
-            self.pixels_to_discard = 0;
-        }
-
-        // check wx glitch
-        if self.use_window && self.wx != self.wx_at_window_start
-            && self.x + 7 >= self.wx as usize
-            && !self.is_wx_glitch_happened {
-                let glitched_pixel = Pixel::new_bg(self.apply_background_palette(0),  0);
-
-                self.bg_fifo.push(glitched_pixel);
-                self.is_wx_glitch_happened = true;
-        }
-    }
 
 /*
 Premier fetch BG resetté : "The first time the background fetcher completes step 3 on a scanline the status is fully reset and operation restarts at Step 1" — tu ne gères pas ce cas particulier du premier fetch.
@@ -625,14 +628,13 @@ C OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
                 && self.wy_equal_ly_condition_met
                 && (self.x + 7 >= self.wx as usize);
 
-            self.handle_window_switch(use_window);
 
             self.step_oam_fetcher();
 
             if !self.fetching_sprite {
                 self.step_pixel_fetcher(use_window);
                 let mut frame = image.lock().unwrap();
-                self.push_pixel_to_screen(&mut frame);
+                self.push_pixel_to_screen(&mut frame, use_window);
             }
         }
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -74,6 +74,7 @@ pub struct Ppu<T: Mbc> {
     is_wx_glitch_happened: bool, // Required to handle the WX hardware glitch
     fetching_sprite: bool, // pixel fetcher and pixel shifter need to be paused while oam fetcher is called
     current_sprite_to_fetch: Option<usize>,
+    wy_equal_ly_condition_met: bool,
 }
 
 impl<T: Mbc> Ppu<T> {
@@ -102,6 +103,7 @@ impl<T: Mbc> Ppu<T> {
             is_wx_glitch_happened: false,
             fetching_sprite: false,
             current_sprite_to_fetch: None,
+            wy_equal_ly_condition_met: false,
         }
     }
 
@@ -458,6 +460,8 @@ impl<T: Mbc> Ppu<T> {
             self.visible_sprites = [None; 10];
             self.oam_search();
 
+            if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
+
             self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
         }
         false
@@ -625,10 +629,11 @@ WY condition : "The condition WY = LY has been true at any point in the currentl
 OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pas vérifiée dans step_oam_fetcher.
 */
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
+
         if self.ly < WIN_SIZE_Y as u8 {
             // let mut pixels = self.render_background();
             let use_window = self.lcd_control.is_window_enabled()
-                && (self.ly as usize >= self.wy as usize)
+                && self.wy_equal_ly_condition_met
                 && (self.x + 7 >= self.wx as usize);
 
             self.handle_window_switch(use_window);
@@ -658,7 +663,7 @@ OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pa
             self.dots -= SCANLINE_DOTS;
 
             if self.lcd_control.is_window_enabled()
-                && self.ly >= self.wy
+                && self.wy_equal_ly_condition_met
                 && self.wx <= 166 {
 
                 self.wly += 1;
@@ -710,6 +715,7 @@ OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pa
                 self.pixels_to_discard = self.scx % 8;
                 self.use_window = false;
                 self.is_wx_glitch_happened = false;
+                self.wy_equal_ly_condition_met = false;
 
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
             }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -472,11 +472,12 @@ impl<T: Mbc> Ppu<T> {
             self.pixel_fetcher.reset();
             self.bg_fifo.clear();
 
-            self.use_window = use_window;
             self.wx_at_window_start = self.wx;
 
             self.pixels_to_discard = 0;
         }
+
+        self.use_window = use_window;
 
         // check wx glitch
         if self.use_window && self.wx != self.wx_at_window_start
@@ -538,7 +539,7 @@ impl<T: Mbc> Ppu<T> {
 
 
     fn step_pixel_fetcher(&mut self, use_window: bool) {
-        let tile_pixels = self.pixel_fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, &self.lcd_control, use_window);
+        let tile_pixels = self.pixel_fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, self.wly, &self.lcd_control, use_window);
 
         if let Some(pixels) = tile_pixels {
             for pixel in pixels {
@@ -615,10 +616,9 @@ impl<T: Mbc> Ppu<T> {
 
 
 /*
-Premier fetch BG resetté : "The first time the background fetcher completes step 3 on a scanline the status is fully reset and operation restarts at Step 1" — tu ne gères pas ce cas particulier du premier fetch.
-Délai après fetch sprite : "If there are less than 6 pixels remaining in the Background FIFO when the sprite fetch is done, the PPU will have to wait" — tu ne gères pas ce délai de 6 - REMAINING_PIXEL_COUNT.
+V Premier fetch BG resetté : "The first time the background fetcher completes step 3 on a scanline the status is fully reset and operation restarts at Step 1" — tu ne gères pas ce cas particulier du premier fetch.
 V WY condition : "The condition WY = LY has been true at any point in the currently rendered frame" — tu vérifies ly >= wy mais pas si cette condition a déjà été vraie pendant la frame courante.
-C OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pas vérifiée dans step_oam_fetcher.
+V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pas vérifiée dans step_oam_fetcher.
 */
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -107,6 +107,7 @@ impl<T: Mbc> Ppu<T> {
         }
     }
 
+
     pub fn display_vram(&self) {
         for i in 0..0x2000 {
             let byte = self
@@ -120,6 +121,7 @@ impl<T: Mbc> Ppu<T> {
             }
         }
     }
+
 
     pub fn display_tiles_data(&self) {
         println!("Tile Data Area:");
@@ -137,6 +139,7 @@ impl<T: Mbc> Ppu<T> {
             println!();
         }
     }
+
 
     pub fn display_tile_map_area(&self, tile_map_address: u16) {
         println!("Tile Map Area at 0x{tile_map_address:04X}:");
@@ -203,12 +206,14 @@ impl<T: Mbc> Ppu<T> {
         frame
     }
 
+
     fn set_pixel_color(&self, frame: &mut [u8], offset: usize, color: Color) {
         let color_rgb = color.to_rgb();
         frame[offset] = color_rgb[0];
         frame[offset + 1] = color_rgb[1];
         frame[offset + 2] = color_rgb[2];
     }
+
 
     fn get_tile_address(&self, y: usize, x: usize, use_window: bool) -> u16 {
         /*
@@ -243,9 +248,9 @@ impl<T: Mbc> Ppu<T> {
         }
     }
 
+
     fn oam_search(&mut self) {
         // Select max 10 visible sprites on the scanline
-
 
         let height:u8 = if self.lcd_control.is_obj_size_8x16() {
             16
@@ -281,59 +286,6 @@ impl<T: Mbc> Ppu<T> {
         Color::from_index(index)
     }
 
-    // fn render_background(&self) -> Vec<Pixel> {
-    //     /*
-    //         Generate one complete scanline (160 pixels) by applying:
-    //             - scroll (SCX/SCY)
-    //             - window (WX/WY)
-    //             - wrapping (256x256)
-    //      */
-
-    //     let mut pixels = Vec::new();
-    //     let ly = self.ly as usize; // line to render
-    //     let default_color = self.apply_background_palette(0);
-
-    //     for x in 0..WIN_SIZE_X {
-    //         // If BG is disabled, color 0 everywhere
-    //         if !self.lcd_control.is_bg_window_enabled() {
-    //             pixels.push(Pixel::new_bg(default_color, 0));
-    //             continue;
-    //         }
-
-    //         // Hardware condition to enable the window
-    //         // WX is shifted by 7 pixels
-    //         let use_window = self.lcd_control.is_window_enabled()
-    //             && (ly >= self.wy as usize)
-    //             && (x + 7 >= self.wx as usize);
-
-    //         let (bg_x, bg_y) = if use_window {
-    //             let win_x = x + 7 - self.wx as usize;
-    //             let win_y = self.wly as usize;
-    //             (win_x % 256, win_y % 256)
-    //         } else {
-    //             // coordinates with scrool (wrap 256)
-    //             (
-    //                 (x + self.scx as usize) % 256,
-    //                 (ly + self.scy as usize) % 256,
-    //             )
-    //         };
-
-    //         let tile_x = bg_x / 8;
-    //         let tile_y = bg_y / 8;
-    //         let tile_address = self.get_tile_address(tile_y, tile_x, use_window);
-    //         let tile = self.read_tile_data(tile_address);
-    //         let pixel_x = bg_x % 8;
-    //         let pixel_y = bg_y % 8;
-
-    //         let color_index = self.get_pixel_color_index(tile, pixel_x, pixel_y);
-    //         let color = self.apply_background_palette(color_index);
-    //         let pixel = Pixel::new_bg(color, color_index);
-            
-    //         pixels.push(pixel);
-    //     }
-
-    //     pixels
-    // }
 
     fn extract_attributes(&self, attributes: u8) -> (bool, bool, bool, bool) {
         (
@@ -352,23 +304,6 @@ impl<T: Mbc> Ppu<T> {
         self.read_tile_data(tile_address)
     }
 
-    fn get_right_pixel(&self, color_index: u8, color: Color, priority: bool) -> Option<Color> {
-        // Deal with sprite/background priority
-        //TODO tmp function to handle the transition between scanline rendering and FIFO.
-        // right now only fifo background is implemented. In order to keep render_sprites working
-        // we need to keep and adapt this function.
-
-        // if old_pixel.get_is_sprite() {
-        //     return None
-        // }
-
-        if priority && color_index != 0 {
-            return None
-        }
-
-        // Some(Pixel::new(color, true, color_index))
-        Some(color)
-    }
 
     fn apply_sprite_palette(&self, color_index: u8, palette_attribute: bool) -> Color {
         let palette_addr = if palette_attribute { OBP1_ADDR } else { OBP0_ADDR };
@@ -397,72 +332,15 @@ impl<T: Mbc> Ppu<T> {
         sprites.into_iter().map(| (_, s) | s).collect()
     }
 
-    // fn render_sprites(&self, image: &mut Arc<Mutex<Vec<u8>>>) {
-    //     /*
-    //         TODO Transition modification until the FIFO OBJ is implemented. Right now the modifications
-    //         should make the function works while we test the FIFO background
-
-    //         Apply sprites above background
-    //         respect:
-    //             - priority
-    //             - flip X/Y
-    //             - palettes
-    //             - transparency
-    //     */
-
-    //     let height: u8 = if self.lcd_control.is_obj_size_8x16() { 16 } else { 8 };
-
-    //     // sort by X then OAM order (hardware behavior)
-    //     let sorted_sprites = self.sort_sprites_by_x();
-
-    //     for sprite in sorted_sprites {
-    //         if !self.lcd_control.is_obj_enabled() {
-    //             continue;
-    //         }
-
-    //         let (priority, y_flip, x_flip, palette_attribute) = self.extract_attributes(sprite.attributes);
-
-    //         // sprite coordinates are shifted: Y - 16, X - 8
-    //         let sprite_top: i16 = sprite.y as i16 - 16;
-    //         let sprite_line = (self.ly as i16 - sprite_top) as usize;
-
-    //         let actual_sprite_line = if y_flip { (height as usize - 1) - sprite_line } else { sprite_line };
-    //         let tile = self.get_sprite_tile(height, sprite, actual_sprite_line);
-
-    //         for pixel_x in 0..8 {
-    //             let screen_x = (sprite.x - 8 + pixel_x) as i16;
-                    
-    //             if !(0..160).contains(&screen_x) {
-    //                 continue;
-    //             }
-
-    //             let actual_pixel_x = if x_flip { 7 - pixel_x } else { pixel_x };
-    //             let color_index = self.get_pixel_color_index(tile, actual_pixel_x as usize, actual_sprite_line % 8); // % 8 to handle 8x16
-
-    //             // 0 = transparency for sprites 
-    //             if color_index == 0 { continue; }
-                    
-    //             let color = self.apply_sprite_palette(color_index, palette_attribute);
-
-    //             if let Some(new_pixel) = self.get_right_pixel(self.bg_color_indices[screen_x as usize], color, priority) {
-    //                 let offset = (self.ly as usize * WIN_SIZE_X + screen_x as usize) * 3;
-    //                 let mut frame = image.lock().unwrap();
-
-    //                 self.set_pixel_color(&mut frame, offset, new_pixel);
-    //             }
-    //         }
-    //     }
-    // }
-
 
     fn mode_oam_search(&mut self) -> bool {
         if self.dots >= OAM_DOTS {
             self.visible_sprites = [None; 10];
             self.oam_search();
 
-
             self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
         }
+
         false
     }
 
@@ -547,7 +425,6 @@ impl<T: Mbc> Ppu<T> {
 
 
     fn step_oam_fetcher(&mut self) {
-
         let height:u8 = if self.lcd_control.is_obj_size_8x16() {
             16
         } else {
@@ -612,13 +489,7 @@ impl<T: Mbc> Ppu<T> {
     }
 
 
-/*
-V Premier fetch BG resetté : "The first time the background fetcher completes step 3 on a scanline the status is fully reset and operation restarts at Step 1" — tu ne gères pas ce cas particulier du premier fetch.
-V WY condition : "The condition WY = LY has been true at any point in the currently rendered frame" — tu vérifies ly >= wy mais pas si cette condition a déjà été vraie pendant la frame courante.
-V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est pas vérifiée dans step_oam_fetcher.
-*/
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
-
         if self.ly < WIN_SIZE_Y as u8 {
             // let mut pixels = self.render_background();
             let use_window = self.lcd_control.is_window_enabled()
@@ -650,15 +521,12 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
 
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
-
-            if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
-
             if self.lcd_control.is_window_enabled()
                 && self.ly >= self.wy
                 && self.wx <= 166 {
                 self.wly += 1;
             }
-            
+
             self.ly += 1;
             self.check_lyc_equals_ly();
 
@@ -696,7 +564,6 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
                 self.check_lyc_equals_ly();
 
                 self.wly = 0;
-
                 // TODO proper reset function
                 self.x = 0;
                 self.bg_fifo.clear();
@@ -716,6 +583,8 @@ V OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'est 
     pub fn tick(&mut self, cycles: u32,  image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         self.update_registers();
         self.dots += cycles;
+
+        if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
 
         match self.lcd_status.get_ppu_mode() {
             PpuMode::OamSearch => self.mode_oam_search(),

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -74,8 +74,7 @@ impl PixelFetcher {
                             self.fetcher_state = FetcherState::Sleep;
                         }
                     } else {
-                        self.reset();
-                        self.first_fetch_done = true;
+                        self.reset_internal(true);
                     }
 
                     return None
@@ -92,11 +91,19 @@ impl PixelFetcher {
         }
     }
 
-    pub fn reset(&mut self) {
+    fn reset_internal(&mut self, first_fetch_done: bool) {
         self.fetcher_state = FetcherState::GetTileId;
         self.fetcher_x = 0;
-        self.first_fetch_done = false;
+        self.first_fetch_done = first_fetch_done;
     }
+
+    pub fn reset_for_scanline(&mut self) {
+        self.reset_internal(false);
+    } 
+
+    pub fn reset_for_window(&mut self) {
+        self.reset_internal(true);
+    } 
 
     pub fn reset_to_state_1(&mut self) {
         self.fetcher_state = FetcherState::GetTileId;

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -271,6 +271,7 @@ mod tests {
 
         fetcher.fetcher_state = FetcherState::PushPixel;
 
+
         let result = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
 
         assert!(result.is_none(), "Should not push when FIFO is not empty");
@@ -281,6 +282,8 @@ mod tests {
     fn test_states_switch_in_right_order_and_timing() {
         let (mut fetcher, mut fifo, lcd) = setup_fetcher();
         let bus = setup_bus();
+
+        fetcher.first_fetch_done = true;
 
         fetcher.dot_counter += 1;
 
@@ -317,6 +320,8 @@ mod tests {
     fn test_tick_pair_fifo_full_at_gethighdata_empty_at_pushpixel() {
         let (mut fetcher, mut fifo, lcd) = setup_fetcher();
         let bus = setup_bus();
+
+        fetcher.first_fetch_done = true;
 
         fetcher.fetcher_state = FetcherState::GetHighData;
         fetcher.dot_counter = 1;
@@ -363,6 +368,8 @@ mod tests {
         let (mut fetcher, fifo, lcd) = setup_fetcher();
         let bus = setup_bus();
 
+        fetcher.first_fetch_done = true;
+
         fetcher.dot_counter += 1;
 
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
@@ -379,5 +386,23 @@ mod tests {
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
         assert!(result.is_some());
         assert_eq!(fetcher.fetcher_x, 1);
+    }
+
+    #[test]
+    fn test_first_fetch_resets_and_does_not_push() {
+        let (mut fetcher, fifo, lcd) = setup_fetcher();
+        let bus = setup_bus();
+
+        fetcher.fetcher_state = FetcherState::GetHighData;
+        fetcher.dot_counter += 1;
+
+        let res1 = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
+        
+        assert!(res1.is_none());
+
+        assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
+        assert_eq!(fetcher.fetcher_x, 0);
+
+        assert!(fetcher.first_fetch_done);
     }
 }

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -31,12 +31,11 @@ pub struct PixelFetcher {
     tile_data_high: u8,
     fetcher_x: u8,
     dot_counter: u32,
-    use_window: bool,
     first_fetch_done: bool,
 }
 
 impl PixelFetcher {
-    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, fifo: &PixelFifo, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
+    pub fn tick<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, fifo: &PixelFifo, ly: u8, scx: u8, scy: u8, wly: u8, lcd_control: &LcdControl, use_window: bool) -> Option<[Pixel; 8]> {
         self.dot_counter = self.dot_counter.wrapping_add(1);
 
         if self.fetcher_state == FetcherState::PushPixel && fifo.is_empty() {
@@ -49,19 +48,19 @@ impl PixelFetcher {
         } else if self.dot_counter % 2 == 0 {
             match self.fetcher_state {
                 FetcherState::GetTileId => {
-                    self.tile_id = self.get_tile_id(bus, ly, scx, scy, lcd_control, use_window);
+                    self.tile_id = self.get_tile_id(bus, ly, scx, scy, wly, lcd_control, use_window);
                     self.fetcher_state = FetcherState::GetLowData;
 
                     return None
                 },
                 FetcherState::GetLowData => {
-                    self.tile_data_low = self.get_tile_data_low(bus, ly, scy, lcd_control);
+                    self.tile_data_low = self.get_tile_data_low(bus, ly, scy, wly, lcd_control, use_window);
                     self.fetcher_state = FetcherState::GetHighData;
 
                     return None
                 },
                 FetcherState::GetHighData => {
-                    self.tile_data_high = self.get_tile_data_high(bus, ly, scy, lcd_control);
+                    self.tile_data_high = self.get_tile_data_high(bus, ly, scy, wly, lcd_control, use_window);
 
                     if self.first_fetch_done {
                         if fifo.is_empty() {
@@ -96,7 +95,6 @@ impl PixelFetcher {
     pub fn reset(&mut self) {
         self.fetcher_state = FetcherState::GetTileId;
         self.fetcher_x = 0;
-        self.use_window = false;
         self.first_fetch_done = false;
     }
 
@@ -104,15 +102,25 @@ impl PixelFetcher {
         self.fetcher_state = FetcherState::GetTileId;
     }
 
-    fn get_tile_id<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, lcd_control: &LcdControl, use_window: bool) -> u8 {
+    fn get_tile_id<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scx: u8, scy: u8, wly: u8, lcd_control: &LcdControl, use_window: bool) -> u8 {
         let tilemap_base: std::ops::Range<u16> = if use_window {
             lcd_control.window_tile_map_area()
         } else {
             lcd_control.bg_tile_map_area()
         };
 
-        let x: u16 = ((scx / 8) as u16 + self.fetcher_x as u16) & 0x1F; // mask to keep the 5 lowest bits
-        let y: u16 = ((ly as u16 + scy as u16) / 8) & 0xFF;
+        let (x, y) = if use_window {
+            (
+                self.fetcher_x as usize,
+                wly as usize / 8,
+            )
+        } else {
+            (
+                ((scx / 8) as usize + self.fetcher_x as usize) & 0x1F, // mask to keep the 5 lowest bits
+                ((ly as usize + scy as usize) / 8) & 0xFF,
+            )
+        };
+
 
         let offset = (y * 32 + x) as u16;
 
@@ -124,8 +132,14 @@ impl PixelFetcher {
         tile_number
     }
 
-    fn get_tile_data_low<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scy: u8, lcd_control: &LcdControl) -> u8 {
-        let correct_byte = ((ly as u16 + scy as u16) % 8) * 2;
+    fn get_tile_data_low<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scy: u8, wly: u8, lcd_control: &LcdControl, use_window: bool) -> u8 {
+        let y = if use_window {
+            wly as usize
+        } else {
+            ly as usize + scy as usize
+        };
+
+        let correct_byte = (y % 8) * 2;
 
         if lcd_control.bg_window_tile_data_area().start == TILE_DATA_1_START {
             let tilemap_base = TILE_DATA_1_START + (self.tile_id as u16) * 16;
@@ -133,7 +147,7 @@ impl PixelFetcher {
             let tile_low = bus
                 .read()
                 .unwrap()
-                .read_byte(tilemap_base + correct_byte);
+                .read_byte(tilemap_base + correct_byte as u16);
 
             tile_low
             
@@ -145,7 +159,7 @@ impl PixelFetcher {
             let tile_low = bus
                 .read()
                 .unwrap()
-                .read_byte(tilemap_base + correct_byte);
+                .read_byte(tilemap_base + correct_byte as u16);
 
             tile_low
         } else {
@@ -154,8 +168,14 @@ impl PixelFetcher {
     }
 
 
-    fn get_tile_data_high<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scy: u8, lcd_control: &LcdControl) -> u8 {
-        let correct_byte = (((ly as u16 + scy as u16) % 8) * 2) + 1;
+    fn get_tile_data_high<T: Mbc>(&mut self, bus: &Arc<RwLock<Mmu<T>>>, ly: u8, scy: u8, wly: u8, lcd_control: &LcdControl, use_window:bool) -> u8 {
+        let y = if use_window {
+            wly as usize
+        } else {
+            ly as usize + scy as usize
+        };
+
+        let correct_byte = ((y % 8) * 2) + 1;
 
         if lcd_control.bg_window_tile_data_area().start == TILE_DATA_1_START {
             let tilemap_base = TILE_DATA_1_START + (self.tile_id as u16) * 16;
@@ -163,7 +183,7 @@ impl PixelFetcher {
             let tile_low = bus
                 .read()
                 .unwrap()
-                .read_byte(tilemap_base + correct_byte);
+                .read_byte(tilemap_base + correct_byte as u16);
 
             tile_low
             
@@ -175,7 +195,7 @@ impl PixelFetcher {
             let tile_low = bus
                 .read()
                 .unwrap()
-                .read_byte(tilemap_base + correct_byte);
+                .read_byte(tilemap_base + correct_byte as u16);
 
             tile_low
         } else {
@@ -251,7 +271,7 @@ mod tests {
 
         fetcher.fetcher_state = FetcherState::PushPixel;
 
-        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
 
         assert!(result.is_none(), "Should not push when FIFO is not empty");
         assert_eq!(fetcher.fetcher_x, 0, "fetcher_x should not increment if the push wasn't done");
@@ -266,22 +286,22 @@ mod tests {
 
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
 
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
         fetcher.dot_counter += 1;
 
         for _ in 0..8 {
             fifo.push(Pixel::default());
         }
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetHighData);        
         fetcher.dot_counter += 1;
 
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::Sleep);        
         fetcher.dot_counter += 1;
 
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::PushPixel);        
         fetcher.dot_counter += 1;
 
@@ -289,7 +309,7 @@ mod tests {
             fifo.pop();
         }
 
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
     }
     
@@ -305,13 +325,13 @@ mod tests {
             fifo.push(Pixel::default());
         }
 
-        let res1 = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        let res1 = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert!(res1.is_none());
         assert_eq!(fetcher.fetcher_state, FetcherState::Sleep);
 
         fetcher.dot_counter += 1;
 
-        let res2 = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        let res2 = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert!(res2.is_none());
         assert_eq!(fetcher.fetcher_state, FetcherState::PushPixel);
 
@@ -319,7 +339,7 @@ mod tests {
             fifo.pop();
         }
 
-        let res3 = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        let res3 = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert!(res3.is_some(), "Should push tile when FIFO becomes empty");
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
         assert_eq!(fetcher.fetcher_x, 1, "fetcher_x should increment after push");
@@ -331,7 +351,7 @@ mod tests {
         let bus = setup_bus();
 
         fetcher.fetcher_state = FetcherState::PushPixel;
-        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
 
         assert!(result.is_some(), "Should push tile when tick is odd and FIFO is empty");
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);
@@ -347,15 +367,15 @@ mod tests {
 
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
 
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetLowData);        
         fetcher.dot_counter += 1;
 
-        fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetHighData);        
         fetcher.dot_counter += 1;
 
-        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, &lcd, false);
+        let result = fetcher.tick(&bus, &fifo, 0, 0, 0, 0, &lcd, false);
         assert_eq!(fetcher.fetcher_state, FetcherState::GetTileId);        
         assert!(result.is_some());
         assert_eq!(fetcher.fetcher_x, 1);

--- a/src/ppu/pixel_fetcher.rs
+++ b/src/ppu/pixel_fetcher.rs
@@ -32,6 +32,7 @@ pub struct PixelFetcher {
     fetcher_x: u8,
     dot_counter: u32,
     use_window: bool,
+    first_fetch_done: bool,
 }
 
 impl PixelFetcher {
@@ -62,18 +63,23 @@ impl PixelFetcher {
                 FetcherState::GetHighData => {
                     self.tile_data_high = self.get_tile_data_high(bus, ly, scy, lcd_control);
 
-                    if fifo.is_empty() {
-                        let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
+                    if self.first_fetch_done {
+                        if fifo.is_empty() {
+                            let tile: Option<[Pixel; 8]> = self.push_pixel(bus);
 
-                        self.fetcher_x += 1;
-                        self.fetcher_state = FetcherState::GetTileId;
+                            self.fetcher_x += 1;
+                            self.fetcher_state = FetcherState::GetTileId;
 
-                        tile
+                            return tile;
+                        } else {
+                            self.fetcher_state = FetcherState::Sleep;
+                        }
                     } else {
-                        self.fetcher_state = FetcherState::Sleep;
-
-                        return None
+                        self.reset();
+                        self.first_fetch_done = true;
                     }
+
+                    return None
                 },
                 FetcherState::Sleep => {
                     self.fetcher_state = FetcherState::PushPixel;
@@ -91,6 +97,7 @@ impl PixelFetcher {
         self.fetcher_state = FetcherState::GetTileId;
         self.fetcher_x = 0;
         self.use_window = false;
+        self.first_fetch_done = false;
     }
 
     pub fn reset_to_state_1(&mut self) {


### PR DESCRIPTION
- The condition WY = LY has been true at any point in the currently rendered frame" je vérifiais ly >= wy mais pas si cette condition a déjà été vraie pendant la frame courante.

- Premier fetch BG resetté : "The first time the background fetcher completes step 3 on a scanline the status is fully reset and operation restarts at Step 1" 

- OBJ disabled : la condition LCDC.1 avant de déclencher le fetch sprite n'était pas vérifiée dans step_oam_fetcher.

- Window rendering in the fetcher takes wly instead of scy for rendering.

- WY = LY était vérifié dans le hblank, ce qui fait que la vérification n'avait pas lieu à la première ligne, avant le premier passage dans celui-ci.

- Le check par rapport à l'activation de la window mid-scanline était fait après le push_pixel au lieu d'avant.