### PR TITLE
138 boot nintendo logo in option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -212,9 +212,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -440,7 +440,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -475,7 +475,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -917,21 +917,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
@@ -1263,7 +1263,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1487,7 +1487,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1702,7 +1702,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1821,9 +1821,10 @@ dependencies = [
 
 [[package]]
 name = "gbmu"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
+ "clap",
  "eframe",
  "egui 0.31.1",
  "egui_extras",
@@ -2858,7 +2859,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3365,7 +3366,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "unicase",
 ]
 
@@ -3396,7 +3397,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3549,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -3637,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3794,7 +3795,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4109,7 +4110,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4133,7 +4134,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4383,9 +4384,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4409,7 +4410,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4460,7 +4461,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4471,7 +4472,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4571,7 +4572,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4689,7 +4690,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4894,7 +4895,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4929,7 +4930,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5407,7 +5408,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5429,7 +5430,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5998,7 +5999,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6085,7 +6086,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6105,7 +6106,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6145,7 +6146,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbmu"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]
@@ -12,3 +12,4 @@ tokio = { version = "1.46.1", features = ["full"] }
 egui_extras = "0.33.0"
 flamegraph = "0.6.11"
 chrono = "0.4.43"
+clap = { version = "4.6.1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ tokio = { version = "1.46.1", features = ["full"] }
 egui_extras = "0.33.0"
 flamegraph = "0.6.11"
 chrono = "0.4.43"
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive", "cargo"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,10 @@ pub struct GameApp<T: Mbc> {
 }
 
 impl<T: Mbc> GameApp<T> {
+    pub fn simulate_boot_rom_effect(&mut self) {
+        println!("Simulating boot sequence");
+    }
+
     pub fn new(
         rom: Vec<u8>,
         receiver: Receiver<DebugCommandQueries>,

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ pub struct GameApp<T: Mbc> {
 
 impl<T: Mbc> GameApp<T> {
     pub fn simulate_boot_rom_effect(&mut self) {
-        println!("Simulating boot sequence");
+        self.gameboy.simulate_boot_rom_effect()
     }
 
     pub fn new(
@@ -34,16 +34,19 @@ impl<T: Mbc> GameApp<T> {
         sender: Sender<DebugResponse>,
         global_bool: Arc<AtomicBool>,
         image_to_change: Arc<Mutex<Vec<u8>>>,
+        boot_with_nintendo: bool,
     ) -> Result<Self, String> {
-        let boot_bytes = std::fs::read("boot-roms/dmg.bin").expect("cannot read boot rom");
-        assert!(boot_bytes.len() == 0x100, "boot rom must be 256 bytes");
+        let boot_rom = if boot_with_nintendo {
+            let boot_bytes = std::fs::read("boot-roms/dmg.bin").expect("cannot read boot rom");
+            assert!(boot_bytes.len() == 0x100, "boot rom must be 256 bytes");
 
-        let mut boot_rom = [0u8; 0x0100];
-        boot_rom.copy_from_slice(&boot_bytes);
+            let mut boot_rom = [0u8; 0x0100];
+            boot_rom.copy_from_slice(&boot_bytes);
+            Some(boot_rom)
+        } else { None };
 
 
         let gameboy = GameBoy::<T>::new(rom, boot_rom, image_to_change.clone())?;
-        println!("{}", gameboy.cpu);
         Ok(Self {
             gameboy,
             debug_receiver: receiver,

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -3,9 +3,9 @@
 
 pub mod debbuger {
 
-    use crate::gui::{DebugCommandQueries, DebugResponse, DebugingDevice};
+    use crate::gui::{DebugCommandQueries, DebugResponse, DebuggingDevice};
 
-    pub fn update_info_struct(game: &mut DebugingDevice) {
+    pub fn update_info_struct(game: &mut DebuggingDevice) {
         let count = 0;
         while let Ok(debug) = game.core_game.debug_response_receiver.try_recv() {
             match debug {
@@ -37,7 +37,7 @@ pub mod debbuger {
         }
     }
 
-    impl DebugingDevice {
+    impl DebuggingDevice {
         pub fn execute_instruction(&self, instr: u8) {
             let _ = self
                 .core_game

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use std::sync::Mutex;
 
 use crate::cpu::Cpu;
+use crate::cpu::registers::{R8, Registers};
 use crate::gui::KeyInput;
 use crate::mmu::mbc::Mbc;
 use crate::mmu::Mmu;
@@ -24,10 +25,10 @@ pub struct GameBoy<T: Mbc> {
 }
 
 impl<T: Mbc>  GameBoy<T> {
-    pub fn new(rom: Vec<u8>, boot_rom: [u8; 0x0100], image: Arc<Mutex<Vec<u8>>>) -> Result<GameBoy<T>, String> {
+    pub fn new(rom: Vec<u8>, boot_rom: Option<[u8; 0x0100]>, image: Arc<Mutex<Vec<u8>>>) -> Result<GameBoy<T>, String> {
         let bus_ref = Arc::new(RwLock::new(Mmu::<T>::new(&rom)?));
 
-        {
+        if let Some(boot_rom) = boot_rom {
             let mut mmu = bus_ref.write().unwrap();
             mmu.load_boot_rom(boot_rom);
         }
@@ -36,6 +37,61 @@ impl<T: Mbc>  GameBoy<T> {
         let ppu = Ppu::<T>::new(bus_ref.clone());
 
         Ok(GameBoy { cpu, bus: bus_ref, ppu, image })
+    }
+
+    pub fn simulate_boot_rom_effect(&mut self) {
+        self.cpu.set_r8_value(R8::A, 0x01);
+        self.cpu.set_r8_value(R8::B, 0xFF);
+        self.cpu.set_r8_value(R8::C, 0x13);
+        self.cpu.set_r8_value(R8::D, 0x00);
+        self.cpu.set_r8_value(R8::E, 0xC1);
+        self.cpu.set_r8_value(R8::H, 0x84);
+        self.cpu.set_r8_value(R8::L, 0x03);
+        self.cpu.pc = 0x0100;
+        self.cpu.registers.set_sp(0xFFFE);
+
+        let mut bus = self.bus.write().unwrap();
+
+        bus.write_byte(0xFF00, 0xCF);
+        bus.write_byte(0xFF01, 0x00);
+        bus.write_byte(0xFF02, 0x7E);
+        bus.write_byte(0xFF04, 0x18);
+        bus.write_byte(0xFF05, 0x00);
+        bus.write_byte(0xFF06, 0x00);
+        bus.write_byte(0xFF07, 0xF8);
+        bus.write_byte(0xFF0F, 0xE1);
+        bus.write_byte(0xFF10, 0x80);
+        bus.write_byte(0xFF11, 0xBF);
+        bus.write_byte(0xFF12, 0xF3);
+        bus.write_byte(0xFF13, 0xFF);
+        bus.write_byte(0xFF14, 0xBF);
+        bus.write_byte(0xFF16, 0x3F);
+        bus.write_byte(0xFF17, 0x00);
+        bus.write_byte(0xFF18, 0xFF);
+        bus.write_byte(0xFF19, 0xBF);
+        bus.write_byte(0xFF1A, 0x7F);
+        bus.write_byte(0xFF1B, 0xFF);
+        bus.write_byte(0xFF1C, 0x9F);
+        bus.write_byte(0xFF1D, 0xFF);
+        bus.write_byte(0xFF1E, 0xBF);
+        bus.write_byte(0xFF20, 0xFF);
+        bus.write_byte(0xFF21, 0x00);
+        bus.write_byte(0xFF22, 0x00);
+        bus.write_byte(0xFF23, 0xBF);
+        bus.write_byte(0xFF24, 0x77);
+        bus.write_byte(0xFF25, 0xF3);
+        bus.write_byte(0xFF26, 0xF1);
+        bus.write_byte(0xFF40, 0x91);
+        bus.write_byte(0xFF41, 0x81);
+        bus.write_byte(0xFF42, 0x00);
+        bus.write_byte(0xFF43, 0x00);
+        bus.write_byte(0xFF44, 0x91);
+        bus.write_byte(0xFF45, 0x00);
+        bus.write_byte(0xFF46, 0xFF);
+        bus.write_byte(0xFF47, 0xFC);
+        bus.write_byte(0xFF4A, 0x00);
+        bus.write_byte(0xFF4B, 0x00);
+        bus.write_byte(0xFFFF, 0x00);
     }
 
     pub fn run_frame(&mut self, key_input: &KeyInput) -> bool {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,9 +6,7 @@ mod common;
 mod views;
 
 use crate::mmu::mbc::{Mbc1, Mbc2, Mbc3, RomOnly};
-use crate::{
-    ppu,
-};
+use crate::ppu;
 use eframe::egui::{Key, TextureHandle};
 use eframe::egui::{load::SizedTexture, vec2, ColorImage, Context, TextureOptions};
 use std::collections::HashSet;
@@ -46,6 +44,45 @@ impl eframe::App for GraphicalApp {
         let duration = debut.elapsed();
         //println!("egui : Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
         ctx.request_repaint();
+    }
+}
+
+pub struct EmulationAppOptions {
+    rom_path: String,
+    boot_rom: bool,
+}
+
+pub struct CoreGameOptions {
+    rom_path: String,
+    boot_rom: bool,
+}
+
+impl From<EmulationAppOptions> for CoreGameOptions {
+    fn from(value: EmulationAppOptions) -> Self {
+        Self {
+            rom_path: value.rom_path,
+            boot_rom: value.boot_rom,
+        }
+    }
+}
+
+impl EmulationAppOptions {
+    pub fn new(rom_path: String, boot_rom: bool) -> Self{
+        Self {
+            rom_path, boot_rom
+        }
+    }
+}
+
+impl GraphicalApp {
+    pub fn create_emulation_app(options: EmulationAppOptions) -> Self {
+        Self {
+            app_state: AppState::EmulationHub(
+                EmulationDevice {
+                    core_game: CoreGameDevice::new(options.into())
+                }
+            )
+        }
     }
 }
 
@@ -129,7 +166,15 @@ impl AnyGameApp {
             AnyGameApp::Mbc1(g)=> g.update(keys_down),
             AnyGameApp::Mbc2(g)=> g.update(keys_down),
             AnyGameApp::Mbc3(g)=> g.update(keys_down),
+        }
+    }
 
+    pub fn simulate_boot_rom_effect(&mut self) {
+        match self {
+            AnyGameApp::OnlyRom(g) => g.simulate_boot_rom_effect(),
+            AnyGameApp::Mbc1(g)=> g.simulate_boot_rom_effect(),
+            AnyGameApp::Mbc2(g)=> g.simulate_boot_rom_effect(),
+            AnyGameApp::Mbc3(g)=> g.simulate_boot_rom_effect(),
         }
     }
 }
@@ -137,6 +182,7 @@ impl AnyGameApp {
 
 async fn launch_game(
     rom_path: String,
+    boot_rom: bool,
     mut input_receiver: Receiver<KeyInput>,
     updated_image_boolean: Arc<AtomicBool>,
     command_query_receiver: Receiver<DebugCommandQueries>,
@@ -160,6 +206,10 @@ async fn launch_game(
             _ => Err("Unmanaged cartridge type")
 
     }?;
+
+    if !boot_rom {
+        app.simulate_boot_rom_effect()
+    }
 
     let input = KeyInput::default();
 
@@ -270,7 +320,7 @@ impl CoreGameDevice {
 
     }
 
-    fn new(path: String) -> Self {
+    fn new(options: CoreGameOptions) -> Self {
         let (input_sender, input_receiver) = channel::<KeyInput>(1);
         let updated_image_boolean = Arc::new(AtomicBool::new(false));
         let (command_query_sender, command_query_receiver) = channel::<DebugCommandQueries>(1);
@@ -283,7 +333,8 @@ impl CoreGameDevice {
             command_query_sender,
             debug_response_receiver,
             handler: tokio::spawn(launch_game(
-                path,
+                options.rom_path,
+                options.boot_rom,
                 input_receiver,
                 updated_image_boolean.clone(),
                 command_query_receiver,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -40,7 +40,7 @@ impl eframe::App for GraphicalApp {
             AppState::StartingHub(device) => device.starting_view(ctx, _frame),
             AppState::SelectionHub(device) => device.selection_view(ctx, _frame),
             AppState::EmulationHub(device) => device.emulation_view(ctx, _frame),
-            AppState::DebugingHub(device) => device.debug_view(ctx, _frame),
+            AppState::DebuggingHub(device) => device.debug_view(ctx, _frame),
             AppState::Default => unreachable!(),
         };
         let duration = debut.elapsed();
@@ -96,7 +96,7 @@ pub enum AppState {
     StartingHub(StartingHubDevice),
     SelectionHub(SelectionDevice),
     EmulationHub(EmulationDevice),
-    DebugingHub(DebugingDevice),
+    DebuggingHub(DebuggingDevice),
     Default,
 }
 
@@ -321,7 +321,7 @@ pub struct EmulationDevice {
     pub core_game: CoreGameDevice,
 }
 
-pub struct DebugingDevice {
+pub struct DebuggingDevice {
     pub core_game: CoreGameDevice,
     /*
     Info stored for the GUI to use them;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -193,10 +193,10 @@ async fn launch_game(
     let rom_data: Vec<u8> = read_rom(rom_path);
     let code = rom_data[0x0147];
     let mut app = match code {
-            0x00 | 0x08 | 0x09 => Ok(AnyGameApp::OnlyRom(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change,)?)),
-            0x01 | 0x02 | 0x03 => Ok(AnyGameApp::Mbc1(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change,)?)),
-            0x05 | 0x06 => Ok(AnyGameApp::Mbc2(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change)?)),
-            0x0F | 0x10 | 0x11 | 0x12 | 0x13 => Ok(AnyGameApp::Mbc3(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change)?)),
+            0x00 | 0x08 | 0x09 => Ok(AnyGameApp::OnlyRom(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change, boot_rom)?)),
+            0x01 | 0x02 | 0x03 => Ok(AnyGameApp::Mbc1(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change, boot_rom)?)),
+            0x05 | 0x06 => Ok(AnyGameApp::Mbc2(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change, boot_rom)?)),
+            0x0F | 0x10 | 0x11 | 0x12 | 0x13 => Ok(AnyGameApp::Mbc3(GameApp::new( rom_data, command_query_receiver, debug_response_sender, global_is_debug, image_to_change, boot_rom)?)),
         /*
             0x0B | 0x0C | 0x0D => Ok(todo!()), // MMM01 pas dans le sujet
             0x19 | 0x1A | 0x1B | 0x1C | 0x1D | 0x1E => Ok(todo!()), // Mbc5

--- a/src/gui/views/debugging_view.rs
+++ b/src/gui/views/debugging_view.rs
@@ -1,14 +1,14 @@
 mod display;
 
 use crate::debugger::debbuger;
-use crate::gui::{AppState, DebugingDevice, WatchedAdresses};
+use crate::gui::{AppState, DebuggingDevice, WatchedAdresses};
 
 use eframe::egui::load::SizedTexture;
 use eframe::egui::Context;
 
 use display::display_interface;
 
-struct DebugingDataIn<'a> {
+struct DebuggingDataIn<'a> {
     is_step: bool,
     watched_address: &'a WatchedAdresses,
     registers: &'a (u8, u8, u8, u8, u8, u8, u8, u16, u16),
@@ -20,7 +20,7 @@ struct DebugingDataIn<'a> {
 }
 
 #[derive(Debug)]
-struct DebugingDataOut {
+struct DebuggingDataOut {
     close_btn_clicked: bool,
     step_clicked: bool,
     step_mode_clicked: bool,
@@ -33,11 +33,11 @@ struct DebugingDataOut {
 
 enum OutState {
     Emulating,
-    Debuging,
+    Debugging,
 }
 
-impl DebugingDevice {
-    fn execute_changes(&mut self, data: DebugingDataOut) -> OutState {
+impl DebuggingDevice {
+    fn execute_changes(&mut self, data: DebuggingDataOut) -> OutState {
         if data.close_btn_clicked {
             return OutState::Emulating;
         }
@@ -61,18 +61,18 @@ impl DebugingDevice {
 
         self.hex_string = data.hex_string;
         if let Ok(result) = u16::from_str_radix(self.hex_string.as_ref(), 16) {}
-        OutState::Debuging
+        OutState::Debugging
     }
 
     pub fn debug_view(mut self, ctx: &Context, _frame: &mut eframe::Frame) -> AppState {
-        let debuging_data_in = self.update_and_get_debuging_data(ctx);
-        let actions_to_perform = display_interface(ctx, _frame, debuging_data_in);
+        let debugging_data_in = self.update_and_get_debugging_data(ctx);
+        let actions_to_perform = display_interface(ctx, _frame, debugging_data_in);
         println!("{actions_to_perform:?}");
         let next_state = self.execute_changes(actions_to_perform);
         self.switch_state(next_state)
     }
 
-    fn update_and_get_debuging_data(&mut self, ctx: &Context) -> DebugingDataIn<'_> {
+    fn update_and_get_debugging_data(&mut self, ctx: &Context) -> DebuggingDataIn<'_> {
         self.core_game.update_and_size_image(ctx);
         debbuger::update_info_struct(self);
 
@@ -81,7 +81,7 @@ impl DebugingDevice {
         } else {
             None
         };
-        DebugingDataIn {
+        DebuggingDataIn {
             is_step: self.is_step,
             sized_texture: self.core_game.sized_image,
             watched_address: &self.watched_adress,
@@ -95,7 +95,7 @@ impl DebugingDevice {
 
     fn switch_state(self, next_state: OutState) -> AppState {
         match next_state {
-            OutState::Debuging => AppState::DebugingHub(self),
+            OutState::Debugging => AppState::DebuggingHub(self),
             OutState::Emulating => AppState::EmulationHub(self.into()),
         }
     }

--- a/src/gui/views/debugging_view/display.rs
+++ b/src/gui/views/debugging_view/display.rs
@@ -5,13 +5,13 @@ use eframe::egui::{
     TextEdit, Ui,
 };
 
-use super::{DebugingDataIn, DebugingDataOut};
+use super::{DebuggingDataIn, DebuggingDataOut};
 
 pub fn display_interface(
     ctx: &Context,
     _frame: &mut eframe::Frame,
-    data: DebugingDataIn,
-) -> DebugingDataOut {
+    data: DebuggingDataIn,
+) -> DebuggingDataOut {
     let (
         close_btn_clicked,
         step_mode_btn_clkd,
@@ -96,7 +96,7 @@ pub fn display_interface(
         display_game(sized_texture, ctx);
     }
 
-    DebugingDataOut {
+    DebuggingDataOut {
         step_clicked: stp_btn_clkd,
         step_mode_clicked: step_mode_btn_clkd,
         close_btn_clicked,
@@ -121,7 +121,7 @@ fn step_button(ui: &mut Ui) -> bool {
     ui.button("Next Step").clicked()
 }
 
-fn get_registers(ui: &mut Ui, debuging_data: &DebugingDataIn) -> bool {
+fn get_registers(ui: &mut Ui, Debugging_data: &DebuggingDataIn) -> bool {
     // Button to refresh registers
     let refresh_button_is_clicked = ui
         .horizontal(|ui| ui.button("🔄 Refresh Registers").clicked())
@@ -143,12 +143,12 @@ fn get_registers(ui: &mut Ui, debuging_data: &DebugingDataIn) -> bool {
             ui.end_row();
 
             let registers_8bit = [
-                ("A", debuging_data.registers.0),
-                ("B", debuging_data.registers.1),
-                ("C", debuging_data.registers.2),
-                ("D", debuging_data.registers.3),
-                ("E", debuging_data.registers.4),
-                ("H", debuging_data.registers.5),
+                ("A", Debugging_data.registers.0),
+                ("B", Debugging_data.registers.1),
+                ("C", Debugging_data.registers.2),
+                ("D", Debugging_data.registers.3),
+                ("E", Debugging_data.registers.4),
+                ("H", Debugging_data.registers.5),
             ];
 
             for (name, value) in registers_8bit.iter() {
@@ -179,9 +179,9 @@ fn get_registers(ui: &mut Ui, debuging_data: &DebugingDataIn) -> bool {
 
             // 16-bit registers
             let registers_16bit = [
-                ("L", debuging_data.registers.6 as u16),
-                ("HL", debuging_data.registers.7),
-                ("SP", debuging_data.registers.8),
+                ("L", Debugging_data.registers.6 as u16),
+                ("HL", Debugging_data.registers.7),
+                ("SP", Debugging_data.registers.8),
             ];
 
             for (name, value) in registers_16bit.iter() {
@@ -207,7 +207,7 @@ fn get_registers(ui: &mut Ui, debuging_data: &DebugingDataIn) -> bool {
     refresh_button_is_clicked
 }
 
-fn get_next_instructions(ui: &mut Ui, data: &DebugingDataIn) -> (u8, bool) {
+fn get_next_instructions(ui: &mut Ui, data: &DebuggingDataIn) -> (u8, bool) {
     // Input section
     let instruction_requested_tuple = ui
         .group(|ui| {
@@ -315,7 +315,7 @@ fn get_next_instructions(ui: &mut Ui, data: &DebugingDataIn) -> (u8, bool) {
     instruction_requested_tuple
 }
 
-fn watch_address(ui: &mut Ui, data: &DebugingDataIn) -> (String, bool) {
+fn watch_address(ui: &mut Ui, data: &DebuggingDataIn) -> (String, bool) {
     let mut hex_string = data.hex_string.clone();
     // Input section with better layout
     let register_new_addr: bool = ui

--- a/src/gui/views/emulation_view.rs
+++ b/src/gui/views/emulation_view.rs
@@ -1,5 +1,5 @@
 use crate::gui::{
-        AppState, CoreGameDevice, DebugingDevice, EmulationDevice, SelectionDevice, WatchedAdresses
+        AppState, CoreGameDevice, DebuggingDevice, EmulationDevice, SelectionDevice, WatchedAdresses
     };
 use eframe::egui::{Context};
 
@@ -26,7 +26,7 @@ impl EmulationDevice {
                     ui.add_space(10.0);
                 });
                 if ui.button("🐛 Open Debug Panel").clicked() {
-                    AppState::DebugingHub(self.into())
+                    AppState::DebuggingHub(self.into())
                 } else {
                     AppState::EmulationHub(self)
                 }
@@ -35,7 +35,7 @@ impl EmulationDevice {
     }
 }
 
-impl From<EmulationDevice> for DebugingDevice {
+impl From<EmulationDevice> for DebuggingDevice {
     fn from(original: EmulationDevice) -> Self {
         original
             .core_game
@@ -65,8 +65,8 @@ impl From<SelectionDevice> for EmulationDevice {
     }
 }
 
-impl From<DebugingDevice> for EmulationDevice {
-    fn from(original: DebugingDevice) -> Self {
+impl From<DebuggingDevice> for EmulationDevice {
+    fn from(original: DebuggingDevice) -> Self {
         original
             .core_game
             .global_is_debug

--- a/src/gui/views/emulation_view.rs
+++ b/src/gui/views/emulation_view.rs
@@ -1,5 +1,5 @@
 use crate::gui::{
-        AppState, CoreGameDevice, DebuggingDevice, EmulationDevice, SelectionDevice, WatchedAdresses
+        AppState, CoreGameDevice, CoreGameOptions, DebuggingDevice, EmulationAppOptions, EmulationDevice, SelectionDevice, WatchedAdresses
     };
 use eframe::egui::{Context};
 
@@ -59,8 +59,12 @@ impl From<EmulationDevice> for DebuggingDevice {
 
 impl From<SelectionDevice> for EmulationDevice {
     fn from(original: SelectionDevice) -> Self {
-        let path = original.path;
-        let core_game = CoreGameDevice::new(path);
+        let rom_path = original.path;
+        let options = CoreGameOptions {
+            rom_path,
+            boot_rom: true,
+        };
+        let core_game = CoreGameDevice::new(options);
         EmulationDevice { core_game }
     }
 }

--- a/src/gui/views/mod.rs
+++ b/src/gui/views/mod.rs
@@ -1,4 +1,4 @@
-mod debuging_view;
+mod debugging_view;
 pub mod emulation_view;
 mod selection_view;
 mod starting_view;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,15 @@ mod gui;
 mod mmu;
 mod ppu;
 
+use clap::{Arg, ArgAction, command};
 use gui::GraphicalApp;
+
+use crate::gui::EmulationAppOptions;
 
 #[tokio::main]
 async fn main() {
+    let start_options = get_matches();
+
     let options = eframe::NativeOptions {
         viewport: eframe::egui::ViewportBuilder::default()
             .with_inner_size([1280.0, 720.0])
@@ -18,9 +23,56 @@ async fn main() {
             .with_resizable(true),
         ..Default::default()
     };
+
+    let app = if let Some(rom_path) = start_options.rom_path {
+        let options = EmulationAppOptions::new(
+            rom_path,
+            start_options.boot_rom
+        );
+        GraphicalApp::create_emulation_app(options)
+    } else {
+        GraphicalApp::default()
+    };
+
     let _ = eframe::run_native(
         "egui Demo",
         options,
-        Box::new(|_cc| Box::new(GraphicalApp::default())),
+        Box::new(|_cc| Box::new(app)),
     );
+}
+
+struct StartOptions {
+    rom_path: Option<String>,
+    boot_rom: bool,
+}
+
+fn get_matches() -> StartOptions {
+    let matches = command!()
+        .arg(
+            Arg::new( "rom_path")
+                .help("The path of the rom you want to launch.")
+        )
+        .arg(
+            Arg::new("boot_rom")
+                .short('b')
+                .long("boot_rom")
+                .action(ArgAction::SetTrue)
+                .required(false)
+                .help("If set, nintendo basic boot rom will boot first.")
+        )
+        .get_matches();
+
+
+    let rom_path = if let Some(path) = matches.get_one::<String>("rom_path") {
+        Some(String::from(path))
+    } else {
+        None
+    };
+
+    let boot_rom = matches.get_flag("boot_rom");
+
+    return StartOptions {
+        rom_path,
+        boot_rom,
+    }
 }


### PR DESCRIPTION
gbmu now takes arguments and build options to launch coregame devices.

Boot can be simulated to be skipped by default or can be launch with -b option. 