### PR TITLE
169 feat map joypad on keyboard

### DIFF
--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -95,37 +95,48 @@ impl<T: Mbc>  GameBoy<T> {
         bus.write_byte(0xFFFF, 0x00);
     }
 
+
     pub fn manage_input(&mut self, key_input: &KeyInput) {
-        if key_input.into() {
-            let mut bus = self.bus.write().unwrap();
-            bus.interrupts_request(Interrupt::Joypad);
-        }
-
-        let bus = self.bus.read().unwrap();
-        let mut p1_joypad = bus.read_byte(0xFF00);
-        drop(bus);
-
-        let (slcted_buttons, slcted_pad) = {
-            (p1_joypad & 0b0010_0000 == 0, p1_joypad & 0b0001_0000 == 0)
+        let old_p1_joypad = {
+            let bus = self.bus.read().unwrap();
+            bus.read_byte(0xFF00)
         };
 
-        p1_joypad &= 0b0011_0000;
-        if slcted_pad {
+        // reset joypad
+        let mut p1_joypad = old_p1_joypad | 0x0F;
+
+        let (selected_buttons, selected_pad) = {
+            (
+                p1_joypad & 0b0010_0000 == 0,
+                p1_joypad & 0b0001_0000 == 0
+            )
+        }; // Bits 5 and 4
+
+        if selected_pad {
             if key_input.down_pushed    { p1_joypad &= 0b1111_0111; }
             if key_input.up_pushed      { p1_joypad &= 0b1111_1011; }
             if key_input.left_pushed    { p1_joypad &= 0b1111_1101; }
             if key_input.right_pushed   { p1_joypad &= 0b1111_1110; }
         }
 
-        if slcted_buttons {
+        if selected_buttons {
             if key_input.start_pushed   { p1_joypad &= 0b1111_0111; }
             if key_input.select_pushed  { p1_joypad &= 0b1111_1011; }
             if key_input.b_pushed       { p1_joypad &= 0b1111_1101; }
             if key_input.a_pushed       { p1_joypad &= 0b1111_1110; }
         }
+
+        let transition_detected = (old_p1_joypad & !p1_joypad) & 0x0F != 0;
+
+        if transition_detected {
+            let mut bus = self.bus.write().unwrap();
+            bus.interrupts_request(Interrupt::Joypad);
+        }
+
         let mut bus = self.bus.write().unwrap();
         bus.write_byte(0xFF00, p1_joypad);
     }
+
 
     pub fn run_frame(&mut self, key_input: &KeyInput) -> bool {
         let mut cycles_elapsed = 0;

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -134,7 +134,7 @@ impl<T: Mbc>  GameBoy<T> {
         }
 
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(0xFF00, p1_joypad);
+        bus.set_joypad_inputs( p1_joypad);
     }
 
 

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -97,44 +97,22 @@ impl<T: Mbc>  GameBoy<T> {
 
 
     pub fn manage_input(&mut self, key_input: &KeyInput) {
-        let old_p1_joypad = {
-            let bus = self.bus.read().unwrap();
-            bus.read_byte(0xFF00)
-        };
 
-        // reset joypad
-        let mut p1_joypad = old_p1_joypad | 0x0F;
+        let mut dpad = 0x0F;
+        if key_input.down_pushed    { dpad &= 0b1111_0111; }
+        if key_input.up_pushed      { dpad &= 0b1111_1011; }
+        if key_input.left_pushed    { dpad &= 0b1111_1101; }
+        if key_input.right_pushed   { dpad &= 0b1111_1110; }
 
-        let (selected_buttons, selected_pad) = {
-            (
-                p1_joypad & 0b0010_0000 == 0,
-                p1_joypad & 0b0001_0000 == 0
-            )
-        }; // Bits 5 and 4
+        let mut buttons = 0x0F;
+        if key_input.start_pushed   { buttons &= 0b1111_0111; }
+        if key_input.select_pushed  { buttons &= 0b1111_1011; }
+        if key_input.b_pushed       { buttons &= 0b1111_1101; }
+        if key_input.a_pushed       { buttons &= 0b1111_1110; }
 
-        if selected_pad {
-            if key_input.down_pushed    { p1_joypad &= 0b1111_0111; }
-            if key_input.up_pushed      { p1_joypad &= 0b1111_1011; }
-            if key_input.left_pushed    { p1_joypad &= 0b1111_1101; }
-            if key_input.right_pushed   { p1_joypad &= 0b1111_1110; }
-        }
-
-        if selected_buttons {
-            if key_input.start_pushed   { p1_joypad &= 0b1111_0111; }
-            if key_input.select_pushed  { p1_joypad &= 0b1111_1011; }
-            if key_input.b_pushed       { p1_joypad &= 0b1111_1101; }
-            if key_input.a_pushed       { p1_joypad &= 0b1111_1110; }
-        }
-
-        let transition_detected = (old_p1_joypad & !p1_joypad) & 0x0F != 0;
-
-        if transition_detected {
-            let mut bus = self.bus.write().unwrap();
-            bus.interrupts_request(Interrupt::Joypad);
-        }
 
         let mut bus = self.bus.write().unwrap();
-        bus.set_joypad_inputs( p1_joypad);
+        bus.update_keys(dpad, buttons);
     }
 
 

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -141,10 +141,8 @@ impl<T: Mbc>  GameBoy<T> {
     pub fn run_frame(&mut self, key_input: &KeyInput) -> bool {
         let mut cycles_elapsed = 0;
 
-
+        self.manage_input(key_input);
         while cycles_elapsed < FRAME_CYCLES {
-            self.manage_input(key_input);
-
             // 1. Tick Timers
             self.bus.write().unwrap().tick_timers();
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -134,8 +134,8 @@ impl Default for KeyMapping {
             start: Key::M,
             up: Key::W,
             down: Key::S,
-            left: Key::D,
-            right: Key::A,
+            left: Key::A,
+            right: Key::D,
         }
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -114,7 +114,7 @@ impl Into<bool> for &KeyInput {
     }
 }
 
-pub struct KeyMaping{
+pub struct KeyMapping{
     pub a: Key,
     pub b: Key,
     pub select: Key,
@@ -125,9 +125,9 @@ pub struct KeyMaping{
     pub right: Key,
 }
 
-impl Default for KeyMaping {
+impl Default for KeyMapping {
     fn default() -> Self {
-        KeyMaping {
+        KeyMapping {
             a: Key::J,
             b: Key::K,
             select: Key::N,
@@ -274,10 +274,10 @@ pub struct CoreGameDevice {
     pub sized_image: Option<SizedTexture>,
     pub global_is_debug: Arc<AtomicBool>,
     texture_handler: Option<TextureHandle>,
-    key_mapping: KeyMaping,
+    key_mapping: KeyMapping,
 }
 
-impl KeyMaping {
+impl KeyMapping {
     pub fn generate_key_input(&self, keys_down: HashSet<Key>) -> KeyInput {
         KeyInput {
             a_pushed: keys_down.contains(&self.a),
@@ -359,7 +359,7 @@ impl CoreGameDevice {
             actual_image,
             global_is_debug,
             sized_image: None,
-            key_mapping: KeyMaping::default(),
+            key_mapping: KeyMapping::default(),
         }
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -223,7 +223,7 @@ async fn launch_game(
         app.simulate_boot_rom_effect()
     }
 
-    let input = KeyInput::default();
+    let mut input = KeyInput::default();
 
     loop {
         time::sleep(TokioDuration::from_millis(1)).await;
@@ -231,11 +231,12 @@ async fn launch_game(
         // du multitask dans le cpu
         // Cela permet de checker si la tache n'a pas ete annule
 
-
-        if let Ok(input) = input_receiver.try_recv(){
-            let input = input;
+        while let Ok(new_input) = input_receiver.try_recv(){
+            input = new_input;
         }
+
         let buffer_was_updated = app.update(&input);
+
         if buffer_was_updated {
             updated_image_boolean.store(true, Ordering::Relaxed);
         }

--- a/src/gui/views/emulation_view.rs
+++ b/src/gui/views/emulation_view.rs
@@ -15,7 +15,7 @@ impl EmulationDevice {
         //println!("update and size image: Temps écoulé : {:?} ({} ms)", duration, duration.as_millis());
         let input = self.core_game.capture_input(ctx);
 
-        self.core_game.input_sender.send(input);
+        let _ = self.core_game.input_sender.try_send(input);
 
         eframe::egui::CentralPanel::default()
             .show(ctx, |ui| {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -138,8 +138,15 @@ impl<T: Mbc> Mmu<T> {
 
                 self.data[mirror as usize] = val;
             }
-            MemoryRegion::Timers => {
-                self.timers.write_byte(addr, val);
+            MemoryRegion::Timers => self.timers.write_byte(addr, val),
+            MemoryRegion::Io => {
+                if addr == 0xFF00 {
+                    let current_inputs = self.data[0xFF00] & 0x0F;
+                    let selection_bits = val & 0x30;
+                    self.data[0xFF00] = 0xC0 | selection_bits | current_inputs;
+                } else {
+                    self.data[addr as usize] = val;
+                }
             }
             MemoryRegion::Oam => self.oam.write(addr, val),
             MemoryRegion::Unusable => {}
@@ -175,6 +182,10 @@ impl<T: Mbc> Mmu<T> {
 
     pub fn get_boot_enable(&self) -> bool {
         self.boot_enable
+    }
+
+    pub fn set_joypad_inputs(&mut self, stat: u8) {
+        self.data[0xFF00] = (self.data[0xFF00] & 0xF0) | (stat & 0x0F);
     }
 }
 

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -140,10 +140,11 @@ impl<T: Mbc> Mmu<T> {
             }
             MemoryRegion::Timers => self.timers.write_byte(addr, val),
             MemoryRegion::Io => {
+                // The CPU can only change the bits 4 and 5. The emulator use set_joypad_inputs instead of write.
                 if addr == 0xFF00 {
                     let current_inputs = self.data[0xFF00] & 0x0F;
-                    let selection_bits = val & 0x30;
-                    self.data[0xFF00] = 0xC0 | selection_bits | current_inputs;
+                    let selection_bits = val & 0b0011_0000;
+                    self.data[0xFF00] = 0b1100_0000 | selection_bits | current_inputs;
                 } else {
                     self.data[addr as usize] = val;
                 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -71,7 +71,9 @@ pub struct Mmu<T: Mbc> {
     timers: Timers,
     oam: Oam,
     boot_enable: bool,
-    boot_rom: [u8; 0x0100]
+    boot_rom: [u8; 0x0100],
+    dpad_state: u8, // for joypad
+    button_state: u8, // for joypad
 }
 
 impl<T: Mbc> Mmu<T> {
@@ -85,6 +87,8 @@ impl<T: Mbc> Mmu<T> {
             oam: Oam::default(),
             boot_enable: false,
             boot_rom: [0xFF; 0x0100],
+            dpad_state: 0x0F,
+            button_state: 0x0F,
         })
     }
 
@@ -109,11 +113,28 @@ impl<T: Mbc> Mmu<T> {
 
         match MemoryRegion::from(addr) {
             MemoryRegion::Mbc | MemoryRegion::ERam => self.cart.read(addr),
-            MemoryRegion::Timers => self.timers.read_byte(addr),
             MemoryRegion::Mram => {
                 let mirror = addr - 0x2000;
 
                 self.data[mirror as usize]
+            }
+            MemoryRegion::Timers => self.timers.read_byte(addr),
+            MemoryRegion::Io => {
+                if addr == 0xFF00 {
+                    let selection = self.data[0xFF00] & 0b0011_0000;
+                    let mut result = 0x0F;
+
+                    if selection & 0b0001_0000 == 0 {
+                        result &= self.dpad_state;
+                    }
+                    if selection & 0b0010_0000 == 0 {
+                        result &= self.button_state;
+                    }
+
+                    0b1100_0000 | selection | result
+                } else {
+                    self.data[addr as usize]
+                }
             }
             MemoryRegion::Oam => self.oam.read(addr),
             MemoryRegion::Unusable => 0xFF,
@@ -140,11 +161,13 @@ impl<T: Mbc> Mmu<T> {
             }
             MemoryRegion::Timers => self.timers.write_byte(addr, val),
             MemoryRegion::Io => {
-                // The CPU can only change the bits 4 and 5. The emulator use set_joypad_inputs instead of write.
+                // The CPU can only change the bits 4 and 5. The emulator use methods to write into the memory.
                 if addr == 0xFF00 {
-                    let current_inputs = self.data[0xFF00] & 0x0F;
                     let selection_bits = val & 0b0011_0000;
+                    let current_inputs = self.data[0xFF00] & 0x0F;
                     self.data[0xFF00] = 0b1100_0000 | selection_bits | current_inputs;
+
+                    self.update_joypad_register();
                 } else {
                     self.data[addr as usize] = val;
                 }
@@ -185,8 +208,29 @@ impl<T: Mbc> Mmu<T> {
         self.boot_enable
     }
 
-    pub fn set_joypad_inputs(&mut self, stat: u8) {
-        self.data[0xFF00] = (self.data[0xFF00] & 0xF0) | (stat & 0x0F);
+    fn update_joypad_register(&mut self) {
+        let mut new_inputs = 0x0F;
+        let selection = self.data[0xFF00] & 0b0011_0000;
+
+        if selection & 0b0001_0000 == 0 {
+            new_inputs &= self.dpad_state;
+        }
+        if selection & 0b0010_0000 == 0 {
+            new_inputs &= self.button_state;
+        }
+
+        let old_inputs = self.data[0xFF00] & 0x0F;
+        if (old_inputs & !new_inputs) & 0x0F != 0 {
+            self.interrupts_request(Interrupt::Joypad);
+        }
+
+        self.data[0xFF00] = 0xC0 | selection | new_inputs;
+    }
+
+    pub fn update_keys(&mut self, dpad: u8, buttons: u8) {
+        self.dpad_state = dpad;
+        self.button_state = buttons;
+        self.update_joypad_register();
     }
 }
 


### PR DESCRIPTION
Les touches étaient déjà mappées par bpoumeau j'avais mal lu le code, mais la logique fonctionnait mal car la fonction considérait qu'on activait une touche en setant le bit correspondant à 1 alors que c'est à 0 qu'il est considéré activé, et le jeu était beaucoup trop lent car la gestion des inputs était exécutée à chaque cycle donc 70000 fois par frame. Il a fallu le sortir de la boucle et gérer les états dans le mmu pour que chaque étape puisse se faire sans souci malgré ça.