### PR TITLE
feat: implement basic OAM DMA

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -168,6 +168,14 @@ impl<T: Mbc> Mmu<T> {
                     self.data[0xFF00] = 0b1100_0000 | selection_bits | current_inputs;
 
                     self.update_joypad_register();
+                } else if addr == 0xFF46 {
+                    self.data[addr as usize] = val;
+
+                    let src_addr = (val as u16) << 8;
+                    for i in 0..160 {
+                        let byte = self.read_byte(src_addr + i);
+                        self.oam.write(0xFE00 + i, byte);
+                    }
                 } else {
                     self.data[addr as usize] = val;
                 }


### PR DESCRIPTION
Adds support for OAM DMA transfers, triggered by writes to 0xFF46. Without this, games could not populate the OAM table (since they almost never write to 0xFE00-0xFE9F directly), which made most sprites invisible

- This is a "one-shot" implementation: the transfer happens instantly instead of taking 160 M-cycles.
- CPU access to memory outside HRAM is not blocked during the transfer.

A better version will come out after the remaking of the PPU.

Oh and... With this PR, the Game Boy officially works for most games. Congrats!