### PR TITLE
feat: Cycle Accurate PPU and specifics cases handling

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -144,7 +144,7 @@ impl<T: Mbc> Cpu<T> {
             return 4;
         }
         if self.handle_ime_state() == StepStatus::Halted {
-            return 5;
+            return 20;
         }
 
         let instruction_byte = self.bus.read().unwrap().read_byte(self.pc);
@@ -161,7 +161,7 @@ impl<T: Mbc> Cpu<T> {
             return 4;
         }
         if self.handle_ime_state() == StepStatus::Halted {
-            return 5;
+            return 20;
         }
 
         let tick_to_wait = self.execute_instruction(instruction);

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -128,7 +128,7 @@ impl<T: Mbc>  GameBoy<T> {
             self.cpu.tick();
 
             // 3. Tick PPU
-            let vblank = self.ppu.tick(1, &mut self.image);
+            let vblank = self.ppu.tick(&mut self.image);
 
             if vblank {
                 return true;

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -124,10 +124,18 @@ impl<T: Mbc>  GameBoy<T> {
             // 1. Tick Timers
             self.bus.write().unwrap().tick_timers();
 
-            // 2. Tick CPU
+            // 2. Tick OAM DMA en M-Cycles
+            if cycles_elapsed % 4 == 0 {
+                let mut bus = self.bus.write().unwrap();
+                if bus.dma_index != 0xFF {
+                    bus.tick_dma();
+                }
+            }
+
+            // 3. Tick CPU
             self.cpu.tick();
 
-            // 3. Tick PPU
+            // 4. Tick PPU
             let vblank = self.ppu.tick(&mut self.image);
 
             if vblank {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -1,6 +1,8 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+use std::sync::{RwLock, RwLockReadGuard};
+
 pub mod interrupt;
 pub mod mbc;
 pub mod timers;
@@ -69,11 +71,12 @@ pub struct Mmu<T: Mbc> {
     cart: T,
     interrupts: InterruptController,
     timers: Timers,
-    oam: Oam,
+    oam: RwLock<Oam>,
     boot_enable: bool,
     boot_rom: [u8; 0x0100],
     dpad_state: u8, // for joypad
     button_state: u8, // for joypad
+    accessed_oam_ram: u8 // for OAM Bug
 }
 
 impl<T: Mbc> Mmu<T> {
@@ -84,11 +87,12 @@ impl<T: Mbc> Mmu<T> {
             cart: T::new(rom_image)?,
             interrupts: InterruptController::new(),
             timers: Timers::default(),
-            oam: Oam::default(),
+            oam: RwLock::new(Oam::default()),
             boot_enable: false,
             boot_rom: [0xFF; 0x0100],
             dpad_state: 0x0F,
             button_state: 0x0F,
+            accessed_oam_ram: 0xFF, // 0xFF means we're not in OAM search mode
         })
     }
 
@@ -136,7 +140,13 @@ impl<T: Mbc> Mmu<T> {
                     self.data[addr as usize]
                 }
             }
-            MemoryRegion::Oam => self.oam.read(addr),
+            MemoryRegion::Oam => {
+                let mut oam = self.oam.write().unwrap();
+                if self.accessed_oam_ram != 0xFF {
+                    oam.trigger_oam_bug_read(self.accessed_oam_ram);
+                }
+                oam.read(addr)
+            },
             MemoryRegion::Unusable => 0xFF,
             MemoryRegion::InterruptFlag => self.interrupts.read_interrupt_flag(),
             MemoryRegion::InterruptEnable => self.interrupts.read_interrupt_enable(),
@@ -181,13 +191,21 @@ impl<T: Mbc> Mmu<T> {
                     let src_addr = (val as u16) << 8;
                     for i in 0..160 {
                         let byte = self.read_byte(src_addr + i);
-                        self.oam.write(0xFE00 + i, byte);
+
+                        let mut oam = self.oam.write().unwrap();
+                        oam.write(0xFE00 + i, byte);
                     }
                 } else {
                     self.data[addr as usize] = val;
                 }
             }
-            MemoryRegion::Oam => self.oam.write(addr, val),
+            MemoryRegion::Oam => {
+                let mut oam = self.oam.write().unwrap();
+                if self.accessed_oam_ram != 0xFF {
+                    oam.trigger_oam_bug_write(self.accessed_oam_ram);
+                }
+                oam.write(addr, val)
+            },
             MemoryRegion::Unusable => {}
             MemoryRegion::InterruptFlag => self.interrupts.write_interrupt_flag(val),
             MemoryRegion::InterruptEnable => self.interrupts.write_interrupt_enable(val),
@@ -215,8 +233,8 @@ impl<T: Mbc> Mmu<T> {
         self.interrupts.request(interrupt);
     }
 
-    pub fn get_oam(&self) -> &Oam {
-        &self.oam
+    pub fn get_oam(&self) -> RwLockReadGuard<'_, Oam> {
+        self.oam.read().unwrap()
     }
 
     pub fn get_boot_enable(&self) -> bool {
@@ -254,6 +272,18 @@ impl<T: Mbc> Mmu<T> {
 
     pub fn set_ly_from_ppu(&mut self, val: u8) {
         self.data[0xFF44] = val;
+    }
+
+    pub fn update_accessed_oam_row(&mut self, val: u8) {
+        if val == 0 || val == 0xFF {
+            self.accessed_oam_ram = val;
+        } else {
+            self.accessed_oam_ram += val;
+        }
+    }
+
+    pub fn trigger_oam_bug_read_increase(&mut self, offset: u8) {
+        self.oam.write().unwrap().trigger_oam_bug_read_increase(offset);
     }
 }
 

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -168,6 +168,13 @@ impl<T: Mbc> Mmu<T> {
                     self.data[0xFF00] = 0b1100_0000 | selection_bits | current_inputs;
 
                     self.update_joypad_register();
+                } else if addr == 0xFF41 { // STAT register
+                    let current_val = self.data[0xFF41 as usize];
+
+                    // We keep 0-2 (PPU), we take 3-6 of CPU (val), bit 7 is always 1
+                    self.data[addr as usize] = (val & 0b0111_1000) | (current_val & 0b0000_0111) | 0x80;
+                } else if addr == 0xFF44 {
+                    // Do nothing, read-only
                 } else if addr == 0xFF46 {
                     self.data[addr as usize] = val;
 
@@ -239,6 +246,14 @@ impl<T: Mbc> Mmu<T> {
         self.dpad_state = dpad;
         self.button_state = buttons;
         self.update_joypad_register();
+    }
+
+    pub fn set_stat_byte_from_ppu(&mut self, val: u8) {
+        self.data[0xFF41] = val;
+    }
+
+    pub fn set_ly_from_ppu(&mut self, val: u8) {
+        self.data[0xFF44] = val;
     }
 }
 

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -76,7 +76,9 @@ pub struct Mmu<T: Mbc> {
     boot_rom: [u8; 0x0100],
     dpad_state: u8, // for joypad
     button_state: u8, // for joypad
-    accessed_oam_ram: u8 // for OAM Bug
+    accessed_oam_ram: u8, // for OAM Bug
+    dma_source: u16,
+    pub dma_index: u8,
 }
 
 impl<T: Mbc> Mmu<T> {
@@ -93,6 +95,8 @@ impl<T: Mbc> Mmu<T> {
             dpad_state: 0x0F,
             button_state: 0x0F,
             accessed_oam_ram: 0xFF, // 0xFF means we're not in OAM search mode
+            dma_source: 0x0,
+            dma_index: 0xFF, // 0xFF means a DMA isn't happening
         })
     }
 
@@ -114,7 +118,7 @@ impl<T: Mbc> Mmu<T> {
         if self.boot_enable && addr <= 0x00FF {
             return self.boot_rom[addr as usize];
         }
-
+        
         match MemoryRegion::from(addr) {
             MemoryRegion::Mbc | MemoryRegion::ERam => self.cart.read(addr),
             MemoryRegion::Mram => {
@@ -187,14 +191,8 @@ impl<T: Mbc> Mmu<T> {
                     // Do nothing, read-only
                 } else if addr == 0xFF46 {
                     self.data[addr as usize] = val;
-
-                    let src_addr = (val as u16) << 8;
-                    for i in 0..160 {
-                        let byte = self.read_byte(src_addr + i);
-
-                        let mut oam = self.oam.write().unwrap();
-                        oam.write(0xFE00 + i, byte);
-                    }
+                    self.dma_index = 0;
+                    self.dma_source = (val as u16) << 8;
                 } else {
                     self.data[addr as usize] = val;
                 }
@@ -284,6 +282,17 @@ impl<T: Mbc> Mmu<T> {
 
     pub fn trigger_oam_bug_read_increase(&mut self, offset: u8) {
         self.oam.write().unwrap().trigger_oam_bug_read_increase(offset);
+    }
+
+    pub fn tick_dma(&mut self) {
+        let byte = self.read_byte(self.dma_source + self.dma_index as u16);
+
+        let mut oam = self.oam.write().unwrap();
+        oam.write(0xFE00 + self.dma_index as u16, byte);
+
+        self.dma_index += 1;
+
+        if self.dma_index == 160 { self.dma_index = 0xFF; }
     }
 }
 

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -272,12 +272,12 @@ impl<T: Mbc> Mmu<T> {
         self.data[0xFF44] = val;
     }
 
+    pub fn set_accessed_oam_row(&mut self, val: u8) {
+        self.accessed_oam_ram = val;
+    }
+
     pub fn update_accessed_oam_row(&mut self, val: u8) {
-        if val == 0 || val == 0xFF {
-            self.accessed_oam_ram = val;
-        } else {
-            self.accessed_oam_ram += val;
-        }
+        self.accessed_oam_ram += val;
     }
 
     pub fn trigger_oam_bug_read_increase(&mut self, offset: u8) {

--- a/src/mmu/oam.rs
+++ b/src/mmu/oam.rs
@@ -47,9 +47,13 @@ impl Oam {
 		Default::default()
 	}
 
-	pub fn read(&self, addr:u16) -> u8 {
-		let sprite = ((addr - OAM_BEGINNING) / 4) as usize;
-		let byte = ((addr - OAM_BEGINNING) % 4) as usize;
+	pub fn read(&self, addr: u16) -> u8 {
+        self.read_raw((addr - OAM_BEGINNING) as u8)
+	}
+
+	pub fn read_raw(&self, offset: u8) -> u8 {
+		let sprite = (offset / 4) as usize;
+		let byte = (offset % 4) as usize;
 
 		match byte {
 			0 => self.sprites[sprite].y,
@@ -60,9 +64,20 @@ impl Oam {
 		}
 	}
 
+    pub fn read_word_raw(&self, offset: u8) -> u16 {
+        let byte_1 = self.read_raw(offset);
+        let byte_2 = self.read_raw(offset + 1);
+
+        ((byte_1  as u16) << 8) | byte_2 as u16
+    }
+
 	pub fn write(&mut self, addr: u16, val: u8) {
-		let sprite = ((addr - OAM_BEGINNING) / 4) as usize;
-		let byte = ((addr - OAM_BEGINNING) % 4) as usize;
+        self.write_raw((addr - OAM_BEGINNING) as u8, val);
+	}
+
+	pub fn write_raw(&mut self, offset: u8, val: u8) {
+		let sprite = (offset / 4) as usize;
+		let byte = (offset % 4) as usize;
 
 		match byte {
 			0 => self.sprites[sprite].y = val,
@@ -72,6 +87,50 @@ impl Oam {
 			_ => (),
 		}
 	}
+
+    pub fn write_word_raw(&mut self, offset: u8, val_1: u8, val_2: u8) {
+        self.write_raw(offset, val_1);
+        self.write_raw(offset + 1, val_2);
+    }
+
+    fn corrupt_words_if_write(&self, mut words: [u16; 4], prev_words: [u16; 4]) -> [u16; 4] {
+        let original_value = words[0];
+        let first_word_of_prev_row = prev_words[0];
+        let third_word_of_prev_row = prev_words[2];
+        words[0] = ((original_value ^ third_word_of_prev_row) & (first_word_of_prev_row ^ third_word_of_prev_row)) ^ third_word_of_prev_row;
+
+        for i in 1..4 {
+            words[i as usize] = prev_words[i as usize];
+        }
+
+        words
+    }
+
+    fn write_corrupt_words_in_oam(&mut self, corrupt_words: [u16; 4], offset: u8, i: usize) {
+        let high_byte = (corrupt_words[i as usize] >> 8) as u8;
+        let low_byte = (corrupt_words[i as usize] & 0xFF) as u8;
+
+        self.write_word_raw(offset + (i * 2) as u8, high_byte, low_byte);
+    }
+
+    pub fn trigger_oam_bug_write(&mut self, offset: u8) {
+        if offset < 8 { return; }
+
+        let prev_offset = offset - 8;
+        let mut words: [u16; 4] = [0; 4];
+        let mut prev_words: [u16; 4] = [0; 4];
+
+        for i in 0..4 {
+            words[i as usize] = self.read_word_raw(offset + (i * 2) as u8);
+            prev_words[i as usize] = self.read_word_raw(prev_offset + (i * 2) as u8);
+        }
+
+        let corrupt_words = self.corrupt_words_if_write(words, prev_words);
+
+        for i in 0..4 {
+            self.write_corrupt_words_in_oam(corrupt_words, offset, i);
+        }
+    }
 }
 
 

--- a/src/mmu/oam.rs
+++ b/src/mmu/oam.rs
@@ -164,6 +164,46 @@ impl Oam {
             self.write_corrupt_words_in_oam(corrupt_words, offset, i);
         }
     }
+
+    fn corrupt_words_if_read_increase(&self, words: [u16; 4], prev_words: [u16; 4],two_prev_words: [u16; 4]) -> u16 {
+        let first_word_two_prev_row = two_prev_words[0];
+        let first_word_prev_row = prev_words[0];
+        let first_word_actual_row = words[0];
+        let third_word_prev_row = prev_words[2];
+
+        (first_word_prev_row & (first_word_two_prev_row | first_word_actual_row | third_word_prev_row))
+            | (first_word_two_prev_row & first_word_actual_row & third_word_prev_row)
+    }
+
+    pub fn trigger_oam_bug_read_increase(&mut self, offset: u8) {
+        // 8 * 4 and 152 since it doesn't apply to the first 4 rows and the last row
+        if offset >= 32 && offset < 152 { 
+            let mut words: [u16; 4] = [0; 4];
+            let mut prev_words: [u16; 4] = [0; 4];
+            let mut two_prev_words: [u16; 4] = [0; 4];
+
+            for i in 0..4 {
+                words[i as usize] = self.read_word_raw(offset + (i * 2) as u8);
+                prev_words[i as usize] = self.read_word_raw((offset - 8) + (i * 2) as u8);
+                two_prev_words[i as usize] = self.read_word_raw((offset - 16) + (i * 2) as u8);
+            }
+
+            prev_words[0] = self.corrupt_words_if_read_increase(words, prev_words, two_prev_words);
+            
+            for i in 0..4 {
+                words[i] = prev_words[i];
+                two_prev_words[i] = prev_words[i];
+            }
+
+            self.write_corrupt_words_in_oam(prev_words, offset - 8, 0);
+            for i in 0..4 {
+                self.write_corrupt_words_in_oam(words, offset, i);
+                self.write_corrupt_words_in_oam(two_prev_words, offset - 16, i);
+            }
+        }
+
+        self.trigger_oam_bug_read(offset);
+    }
 }
 
 

--- a/src/mmu/oam.rs
+++ b/src/mmu/oam.rs
@@ -131,6 +131,39 @@ impl Oam {
             self.write_corrupt_words_in_oam(corrupt_words, offset, i);
         }
     }
+
+    fn corrupt_words_if_read(&self, mut words: [u16; 4], prev_words: [u16; 4]) -> [u16; 4] {
+        let original_value = words[0];
+        let first_word_of_prev_row = prev_words[0];
+        let third_word_of_prev_row = prev_words[2];
+        words[0] = first_word_of_prev_row | (original_value & third_word_of_prev_row);
+
+        for i in 1..4 {
+            words[i as usize] = prev_words[i as usize];
+        }
+
+        words
+    }
+
+    pub fn trigger_oam_bug_read(&mut self, offset: u8) {
+        if offset < 8 { return; }
+
+        let prev_offset = offset - 8;
+        let mut words: [u16; 4] = [0; 4];
+        let mut prev_words: [u16; 4] = [0; 4];
+
+        for i in 0..4 {
+            words[i as usize] = self.read_word_raw(offset + (i * 2) as u8);
+            prev_words[i as usize] = self.read_word_raw(prev_offset + (i * 2) as u8);
+        }
+
+        let corrupt_words = self.corrupt_words_if_read(words, prev_words);
+
+        self.write_corrupt_words_in_oam(corrupt_words, offset - 8, 0);
+        for i in 0..4 {
+            self.write_corrupt_words_in_oam(corrupt_words, offset, i);
+        }
+    }
 }
 
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -32,7 +32,6 @@ pub const WIN_SIZE_X: usize = 160; // Window size in X direction
 pub const WIN_SIZE_Y: usize = 144; // Window size in Y direction
 pub const VBLANK_SIZE: usize = 10; // VBlank size in lines
 const VRAM: MemoryRegion = MemoryRegion::Vram; // Start of VRAM
-const OAM: MemoryRegion = MemoryRegion::Oam; // Start of OAM
 const LY_ADDR: u16 = 0xFF44; // LCDC Y-Coordinate
 const LYC_ADDR: u16 = 0xFF45; // LY Compare
 const STAT_ADDR: u16 = 0xFF41; // LCDC Status
@@ -56,6 +55,7 @@ pub struct Ppu<T: Mbc> {
     lcd_status: LcdStatus, // LCD Status register
     wly: u8,               // Window internal line counter
     ly: u8,
+    internal_ly: u8, // needed for the ly=153 quirk
     x: usize,
     pixel_fetcher: PixelFetcher,
     oam_fetcher: OamFetcher,
@@ -82,6 +82,7 @@ impl<T: Mbc> Ppu<T> {
             lcd_status: LcdStatus::new(),
             wly: 0x00,
             ly: 0x00,
+            internal_ly: 0x00,
             x: 0,
             pixel_fetcher: PixelFetcher::default(),
             oam_fetcher: OamFetcher::default(),
@@ -541,7 +542,7 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
-    fn reset_hvblank(&mut self) {
+    fn reset_for_new_scanline(&mut self) {
         self.x = 0;
         self.bg_fifo.clear();
         self.obj_piso.reset();
@@ -551,27 +552,31 @@ impl<T: Mbc> Ppu<T> {
         self.is_wx_glitch_happened = false;
     }
 
-    fn mode_hblank(&mut self) -> bool {
-        // End of scanline -> next one after 456 dots
+    fn advance_to_next_scanline(&mut self) {
+        let wy = self.read_wy();
+        let wx = self.read_wx();
 
+        if self.read_lcdc().is_window_enabled()
+            && self.ly >= wy
+            && wx <= 166 {
+            self.wly += 1;
+        }
+
+        self.ly += 1;
+        self.internal_ly += 1;
+        self.write_ly_to_mmu();
+
+        self.check_lyc_equals_ly();
+
+        self.reset_for_new_scanline();
+    }
+
+    // End of scanline
+    fn mode_hblank(&mut self) -> bool {
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
             
-            let wy = self.read_wy();
-            let wx = self.read_wx();
-
-            if self.read_lcdc().is_window_enabled()
-                && self.ly >= wy
-                && wx <= 166 {
-                self.wly += 1;
-            }
-
-            self.ly += 1;
-            self.write_ly_to_mmu();
-
-            self.check_lyc_equals_ly();
-
-            self.reset_hvblank();
+            self.advance_to_next_scanline();
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);
@@ -588,31 +593,48 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
+    fn handle_ly153_quirk(&mut self) {
+        self.ly = 0;
+        self.write_ly_to_mmu();
+        self.check_lyc_equals_ly();
+    }
+
+    fn end_frame(&mut self) {
+        self.internal_ly = 0;
+        self.ly = 0;
+        self.write_ly_to_mmu();
+        
+        self.wly = 0;
+        self.reset_for_new_scanline();
+        self.wy_equal_ly_condition_met = false;
+
+        self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
+        self.write_stat_to_mmu();
+    }
+
+    fn advance_vblank_scanline(&mut self) {
+        self.internal_ly += 1;
+        self.ly = self.internal_ly;
+        self.write_ly_to_mmu();
+        self.check_lyc_equals_ly();
+    }
+
+    // End of frame
     fn mode_vblank(&mut self) -> bool {
+        if self.internal_ly == 153 && self.dots == 4 {
+            self.handle_ly153_quirk();
+        }
+
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
 
-            self.ly += 1;
-            self.write_ly_to_mmu();
-
-            self.check_lyc_equals_ly();
-
-            if self.ly >= WIN_SIZE_Y as u8 + VBLANK_SIZE as u8 {
-                self.ly = 0;
-                self.write_ly_to_mmu();
-               
-                self.check_lyc_equals_ly();
-
-                self.wly = 0;
-
-                self.reset_hvblank();
-
-                self.wy_equal_ly_condition_met = false;
-
-                self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
-                self.write_stat_to_mmu();
+            if self.internal_ly == 153 {
+                self.end_frame();
+            } else {
+                self.advance_vblank_scanline();
             }
         }
+            
         false
     }
 
@@ -621,6 +643,7 @@ impl<T: Mbc> Ppu<T> {
 
         if !self.read_lcdc().is_ppu_enabled() {
             self.ly = 0;
+            self.internal_ly = 0;
             self.write_ly_to_mmu();
 
             self.dots = 0;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -339,7 +339,7 @@ impl<T: Mbc> Ppu<T> {
             self.oam_search();
 
             self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
-            self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+            self.write_stat_to_mmu();
         }
 
         false
@@ -507,7 +507,7 @@ impl<T: Mbc> Ppu<T> {
         if self.x == 160 {
             // self.render_sprites(image);
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
-            self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+            self.write_stat_to_mmu();
         }
 
         false
@@ -526,7 +526,7 @@ impl<T: Mbc> Ppu<T> {
             }
 
             self.ly += 1;
-            self.write_ly_to_mmu(self.ly);
+            self.write_ly_to_mmu();
 
             self.check_lyc_equals_ly();
 
@@ -542,14 +542,14 @@ impl<T: Mbc> Ppu<T> {
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);
-                self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+                self.write_stat_to_mmu();
 
                 self.bus.write().unwrap().interrupts_request(Interrupt::VBlank);
 
                 return true;
             } else {
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
-                self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+                self.write_stat_to_mmu();
             }
         }
         false
@@ -560,13 +560,13 @@ impl<T: Mbc> Ppu<T> {
             self.dots -= SCANLINE_DOTS;
 
             self.ly += 1;
-            self.write_ly_to_mmu(self.ly);
+            self.write_ly_to_mmu();
 
             self.check_lyc_equals_ly();
 
             if self.ly >= WIN_SIZE_Y as u8 + VBLANK_SIZE as u8 {
                 self.ly = 0;
-                self.write_ly_to_mmu(self.ly);
+                self.write_ly_to_mmu();
                
                 self.check_lyc_equals_ly();
 
@@ -582,7 +582,7 @@ impl<T: Mbc> Ppu<T> {
                 self.wy_equal_ly_condition_met = false;
 
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
-                self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+                self.write_stat_to_mmu();
             }
         }
         false
@@ -593,11 +593,11 @@ impl<T: Mbc> Ppu<T> {
 
         if !self.lcd_control.is_ppu_enabled() {
             self.ly = 0;
-            self.write_ly_to_mmu(self.ly);
+            self.write_ly_to_mmu();
 
             self.dots = 0;
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
-            self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+            self.write_stat_to_mmu();
             return false;
         }
 
@@ -624,9 +624,9 @@ impl<T: Mbc> Ppu<T> {
         */
         let lyc_match = self.ly == self.lyc;
         self.lcd_status.set_lyc_equals_ly(lyc_match);
-        self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
+        self.write_stat_to_mmu();
         
-        if lyc_match && self.lcd_status.get_lyc_equals_ly() {
+        if self.lcd_status.get_lyc_equals_ly() {
             self.bus.write().unwrap().interrupts_request(Interrupt::LcdStat);
         }
     }
@@ -643,13 +643,13 @@ impl<T: Mbc> Ppu<T> {
     }
 
 
-    fn write_ly_to_mmu(&mut self, ly: u8) {
+    fn write_ly_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(LY_ADDR, ly);
+        bus.write_byte(LY_ADDR, self.ly);
     }
 
-    fn write_stat_to_mmu(&mut self, stat: u8) {
+    fn write_stat_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(STAT_ADDR, stat);
+        bus.write_byte(STAT_ADDR, self.lcd_status.struct_to_byte());
     }
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -369,6 +369,7 @@ impl<T: Mbc> Ppu<T> {
         if self.dots >= OAM_DOTS {
             let sorted = self.sort_sprites_by_x();
             self.visible_sprites = [None; 10];
+
             for (i, sprite) in sorted.into_iter().enumerate() {
                 self.visible_sprites[i] = Some(sprite);
             }
@@ -541,14 +542,13 @@ impl<T: Mbc> Ppu<T> {
                 && self.wy_equal_ly_condition_met
                 && (self.x + 7 >= wx as usize);
 
-
             self.step_oam_fetcher();
 
             if !self.fetching_sprite {
+                self.step_pixel_fetcher(use_window);
                 if self.stall_dots > 0 {
                     self.stall_dots -= 1;
                 } else {
-                    self.step_pixel_fetcher(use_window);
                     let mut frame = image.lock().unwrap();
                     self.handle_window_switch(use_window);
                     self.push_pixel_to_screen(&mut frame, use_window);
@@ -572,6 +572,7 @@ impl<T: Mbc> Ppu<T> {
         self.use_window = false;
         self.is_wx_glitch_happened = false;
         self.is_first_scanline_after_lcd_on = false;
+        self.stall_dots = 0;
     }
 
     fn advance_to_next_scanline(&mut self) {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -53,15 +53,9 @@ const SCANLINE_DOTS: u32 = 456; // always 456
 pub struct Ppu<T: Mbc> {
     pub bus: Arc<RwLock<Mmu<T>>>,
     pub dots: u32,
-    lcd_control: LcdControl,
     lcd_status: LcdStatus, // LCD Status register
-    scx: u8,               // Scroll X
-    scy: u8,               // Scroll Y
-    wy: u8,                // Window Y position
-    wx: u8,                // Window X position
     wly: u8,               // Window internal line counter
     ly: u8,
-    lyc: u8,
     x: usize,
     pixel_fetcher: PixelFetcher,
     oam_fetcher: OamFetcher,
@@ -82,15 +76,9 @@ impl<T: Mbc> Ppu<T> {
         Ppu {
             bus,
             dots: 0,
-            lcd_control: LcdControl::default(),
             lcd_status: LcdStatus::new(),
-            scx: 0x00,
-            scy: 0x00,
-            wy: 0x00,
-            wx: 0x00,
             wly: 0x00,
             ly: 0x00,
-            lyc: 0x00,
             x: 0,
             pixel_fetcher: PixelFetcher::default(),
             oam_fetcher: OamFetcher::default(),
@@ -224,9 +212,9 @@ impl<T: Mbc> Ppu<T> {
         */
 
         let tilemap_base: std::ops::Range<u16> = if use_window {
-            self.lcd_control.window_tile_map_area()
+            self.read_lcdc().window_tile_map_area()
         } else {
-            self.lcd_control.bg_tile_map_area()
+            self.read_lcdc().bg_tile_map_area()
         };
 
         let offset = (y * 32 + x) as u16;
@@ -235,7 +223,7 @@ impl<T: Mbc> Ppu<T> {
             .read()
             .unwrap()
             .read_byte(tilemap_base.start + offset);
-        match self.lcd_control.bg_window_tile_data_area() {
+        match self.read_lcdc().bg_window_tile_data_area() {
             // Unsigned mode: simple multiplication
             lcd_control::TILE_DATA_1 => 0x8000 + (tile_number as u16) * 16,
             // Signed mode: tile_number is interpreted as i8 ([-128;127]), base = 0x9000
@@ -252,7 +240,7 @@ impl<T: Mbc> Ppu<T> {
     fn oam_search(&mut self) {
         // Select max 10 visible sprites on the scanline
 
-        let height:u8 = if self.lcd_control.is_obj_size_8x16() {
+        let height:u8 = if self.read_lcdc().is_obj_size_8x16() {
             16
         } else {
             8
@@ -351,15 +339,16 @@ impl<T: Mbc> Ppu<T> {
             self.pixel_fetcher.reset_for_window();
             self.bg_fifo.clear();
 
-            self.wx_at_window_start = self.wx;
+            self.wx_at_window_start = self.read_wx();
             self.pixels_to_discard = 0;
         }
 
         self.use_window = use_window;
 
         // check wx glitch
-        if self.use_window && self.wx != self.wx_at_window_start
-            && self.x + 7 >= self.wx as usize
+        let wx = self.read_wx();
+        if self.use_window && wx != self.wx_at_window_start
+            && self.x + 7 >= wx as usize
             && !self.is_wx_glitch_happened {
                 let glitched_pixel = Pixel::new_bg(self.apply_background_palette(0),  0);
 
@@ -379,7 +368,7 @@ impl<T: Mbc> Ppu<T> {
                 let bg_color: Color;
 
                 // If BG is disabled, color 0 everywhere
-                if !self.lcd_control.is_bg_window_enabled() {
+                if !self.read_lcdc().is_bg_window_enabled() {
                     bg_color_index = 0;
                     bg_color = self.apply_background_palette(0);
                 }
@@ -415,7 +404,10 @@ impl<T: Mbc> Ppu<T> {
 
 
     fn step_pixel_fetcher(&mut self, use_window: bool) {
-        let tile_pixels = self.pixel_fetcher.tick(&self.bus, &self.bg_fifo, self.ly, self.scx, self.scy, self.wly, &self.lcd_control, use_window);
+        let scy = self.read_scy();
+        let scx = self.read_scx();
+
+        let tile_pixels = self.pixel_fetcher.tick(&self.bus, &self.bg_fifo, self.ly, scx, scy, self.wly, &self.read_lcdc(), use_window);
 
         if let Some(pixels) = tile_pixels {
             for pixel in pixels {
@@ -426,7 +418,7 @@ impl<T: Mbc> Ppu<T> {
 
 
     fn step_oam_fetcher(&mut self) {
-        let height:u8 = if self.lcd_control.is_obj_size_8x16() {
+        let height:u8 = if self.read_lcdc().is_obj_size_8x16() {
             16
         } else {
             8
@@ -435,12 +427,14 @@ impl<T: Mbc> Ppu<T> {
         if self.fetching_sprite {
             if let Some(index) = self.current_sprite_to_fetch {
                 if let Some(sprite) = self.visible_sprites[index] {
+                    let lcdc = self.read_lcdc();
+
                     self.fetching_sprite = !self.oam_fetcher.tick(
                         &self.bus,
                         &sprite,
                         &mut self.obj_piso,
                         self.ly,
-                        &self.lcd_control,
+                        &lcdc,
                         height,
                         self.x,
                     );
@@ -453,7 +447,9 @@ impl<T: Mbc> Ppu<T> {
             };
         }
         else {
-            if !self.lcd_control.is_obj_enabled() { return; }
+            if !self.read_lcdc().is_obj_enabled() { return; }
+
+            let lcdc = self.read_lcdc();
 
             for (index, sprite_opt) in self.visible_sprites.iter_mut().enumerate() {
                 if let Some(sprite) = sprite_opt {
@@ -464,12 +460,13 @@ impl<T: Mbc> Ppu<T> {
 
                         self.current_sprite_to_fetch = Some(index);
                         self.pixel_fetcher.reset_to_state_1();
+
                         self.fetching_sprite = !self.oam_fetcher.tick(
                             &self.bus,
                             sprite,
                             &mut self.obj_piso,
                             self.ly,
-                            &self.lcd_control,
+                            &lcdc,
                             height,
                             self.x,
                         );
@@ -488,10 +485,11 @@ impl<T: Mbc> Ppu<T> {
 
     fn mode_pixel_transfer(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         if self.ly < WIN_SIZE_Y as u8 {
-            // let mut pixels = self.render_background();
-            let use_window = self.lcd_control.is_window_enabled()
+            let wx = self.read_wx();
+
+            let use_window = self.read_lcdc().is_window_enabled()
                 && self.wy_equal_ly_condition_met
-                && (self.x + 7 >= self.wx as usize);
+                && (self.x + 7 >= wx as usize);
 
 
             self.step_oam_fetcher();
@@ -505,7 +503,6 @@ impl<T: Mbc> Ppu<T> {
         }
 
         if self.x == 160 {
-            // self.render_sprites(image);
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
             self.write_stat_to_mmu();
         }
@@ -519,9 +516,13 @@ impl<T: Mbc> Ppu<T> {
 
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
-            if self.lcd_control.is_window_enabled()
-                && self.ly >= self.wy
-                && self.wx <= 166 {
+            
+            let wy = self.read_wy();
+            let wx = self.read_wx();
+
+            if self.read_lcdc().is_window_enabled()
+                && self.ly >= wy
+                && wx <= 166 {
                 self.wly += 1;
             }
 
@@ -536,7 +537,10 @@ impl<T: Mbc> Ppu<T> {
             self.bg_fifo.clear();
             self.obj_piso.reset();
             self.pixel_fetcher.reset_for_scanline();
-            self.pixels_to_discard = self.scx % 8;
+
+            let scx = self.read_scx();
+
+            self.pixels_to_discard = scx % 8;
             self.use_window = false;
             self.is_wx_glitch_happened = false;
 
@@ -576,7 +580,10 @@ impl<T: Mbc> Ppu<T> {
                 self.bg_fifo.clear();
                 self.obj_piso.reset();
                 self.pixel_fetcher.reset_for_scanline();
-                self.pixels_to_discard = self.scx % 8;
+
+                let scx = self.read_scx();
+
+                self.pixels_to_discard = scx % 8;
                 self.use_window = false;
                 self.is_wx_glitch_happened = false;
                 self.wy_equal_ly_condition_met = false;
@@ -591,7 +598,7 @@ impl<T: Mbc> Ppu<T> {
     pub fn tick(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         self.fetch_data_from_mmu();
 
-        if !self.lcd_control.is_ppu_enabled() {
+        if !self.read_lcdc().is_ppu_enabled() {
             self.ly = 0;
             self.write_ly_to_mmu();
 
@@ -603,7 +610,9 @@ impl<T: Mbc> Ppu<T> {
 
         self.dots += 1;
 
-        if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
+        let wy = self.read_wy();
+
+        if wy == self.ly { self.wy_equal_ly_condition_met = true; }
 
         let was_updated = match self.lcd_status.get_ppu_mode() {
             PpuMode::OamSearch => self.mode_oam_search(),
@@ -622,7 +631,7 @@ impl<T: Mbc> Ppu<T> {
                 - can trigger a LCD STAT interrupt
             It's used by many games to synchronize with scanline
         */
-        let lyc_match = self.ly == self.lyc;
+        let lyc_match = self.ly == self.read_lyc();
         self.lcd_status.set_lyc_equals_ly(lyc_match);
         self.write_stat_to_mmu();
         
@@ -633,15 +642,40 @@ impl<T: Mbc> Ppu<T> {
 
     pub fn fetch_data_from_mmu(&mut self) {
         let bus = self.bus.read().unwrap();
-        self.lcd_control.update_from_byte(bus.read_byte(LCD_CONTROL_ADDR));
         self.lcd_status.update_from_byte(bus.read_byte(STAT_ADDR));
-        self.scy = bus.read_byte(SCY_ADDR);
-        self.scx = bus.read_byte(SCX_ADDR);
-        self.lyc = bus.read_byte(LYC_ADDR);
-        self.wy = bus.read_byte(WY_ADDR);
-        self.wx = bus.read_byte(WX_ADDR);
     }
 
+    fn read_scy(&self) -> u8 {
+        let bus = self.bus.read().unwrap();
+        bus.read_byte(SCY_ADDR)
+    }
+
+    fn read_scx(&self) -> u8 {
+        let bus = self.bus.read().unwrap();
+        bus.read_byte(SCX_ADDR)
+    }
+
+    fn read_wy(&self) -> u8 {
+        let bus = self.bus.read().unwrap();
+        bus.read_byte(WY_ADDR)
+    }
+
+    fn read_wx(&self) -> u8 {
+        let bus = self.bus.read().unwrap();
+        bus.read_byte(WX_ADDR)
+    }
+
+    fn read_lyc(&self) -> u8 {
+        let bus = self.bus.read().unwrap();
+        bus.read_byte(LYC_ADDR)
+    }
+
+    fn read_lcdc(&self) -> LcdControl {
+        let bus = self.bus.read().unwrap();
+        let byte = bus.read_byte(LCD_CONTROL_ADDR);
+
+        LcdControl::from_byte(byte)
+    }
 
     fn write_ly_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -339,6 +339,7 @@ impl<T: Mbc> Ppu<T> {
 
     fn mode_oam_search(&mut self) -> bool {
         if self.dots == 1 {
+            self.bus.write().unwrap().update_accessed_oam_row(0);
             self.oam_scan_index = 0;
             self.visible_sprites_count = 0;
             self.visible_sprites = [None; 10];
@@ -366,6 +367,11 @@ impl<T: Mbc> Ppu<T> {
             self.oam_scan_index += 1;
         }
 
+        // accessed_oam_row count in M-cycles
+        if self.dots % 4 == 0 {
+            self.bus.write().unwrap().update_accessed_oam_row(8);
+        }
+
         if self.dots >= OAM_DOTS {
             let sorted = self.sort_sprites_by_x();
             self.visible_sprites = [None; 10];
@@ -375,6 +381,7 @@ impl<T: Mbc> Ppu<T> {
             }
 
             self.update_ppu_mode(PpuMode::PixelTransfer);
+            self.bus.write().unwrap().update_accessed_oam_row(0xFF);
         }
 
         false

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -72,6 +72,8 @@ pub struct Ppu<T: Mbc> {
     oam_scan_index: u8, // index scanned sprites in OAM Search
     visible_sprites_count: u8,
     current_obj_height: u8,
+    lcd_was_enabled: bool, // for the LCD on/off quirk. We need to detect if the ppu is on for the first time since it was off.
+    is_first_scanline_after_lcd_on: bool, // for the LCD on/off quirk. If first scanline since the ppu is on, the cycle is shorter.
 }
 
 impl<T: Mbc> Ppu<T> {
@@ -99,6 +101,8 @@ impl<T: Mbc> Ppu<T> {
             oam_scan_index: 0,
             visible_sprites_count: 0,
             current_obj_height: 0,
+            lcd_was_enabled: false,
+            is_first_scanline_after_lcd_on: false,
         }
     }
 
@@ -550,6 +554,7 @@ impl<T: Mbc> Ppu<T> {
         self.pixels_to_discard = self.read_scx() % 8;
         self.use_window = false;
         self.is_wx_glitch_happened = false;
+        self.is_first_scanline_after_lcd_on = false;
     }
 
     fn advance_to_next_scanline(&mut self) {
@@ -573,8 +578,14 @@ impl<T: Mbc> Ppu<T> {
 
     // End of scanline
     fn mode_hblank(&mut self) -> bool {
-        if self.dots >= SCANLINE_DOTS {
-            self.dots -= SCANLINE_DOTS;
+        let scanline_dots = if self.is_first_scanline_after_lcd_on {
+            SCANLINE_DOTS - 16
+        } else {
+            SCANLINE_DOTS
+        };
+
+        if self.dots >= scanline_dots {
+            self.dots -= scanline_dots;
             
             self.advance_to_next_scanline();
 
@@ -638,18 +649,29 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
+    fn reset_when_ppu_disabled(&mut self) {
+        self.ly = 0;
+        self.internal_ly = 0;
+        self.write_ly_to_mmu();
+
+        self.dots = 0;
+        self.lcd_status.update_ppu_mode(PpuMode::HBlank);
+        self.write_stat_to_mmu();
+
+        self.lcd_was_enabled = false;
+    }
+
     pub fn tick(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         self.read_lcd_status();
 
         if !self.read_lcdc().is_ppu_enabled() {
-            self.ly = 0;
-            self.internal_ly = 0;
-            self.write_ly_to_mmu();
-
-            self.dots = 0;
-            self.lcd_status.update_ppu_mode(PpuMode::HBlank);
-            self.write_stat_to_mmu();
+            self.reset_when_ppu_disabled();
             return false;
+        }
+
+        if !self.lcd_was_enabled {
+            self.is_first_scanline_after_lcd_on = true;
+            self.lcd_was_enabled = true;
         }
 
         self.dots += 1;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -12,6 +12,7 @@ mod oam_fetcher;
 
 use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
+use std::thread::current;
 
 use crate::mmu::mbc::Mbc;
 use crate::mmu::MemoryRegion;
@@ -74,6 +75,7 @@ pub struct Ppu<T: Mbc> {
     current_obj_height: u8,
     lcd_was_enabled: bool, // for the LCD on/off quirk. We need to detect if the ppu is on for the first time since it was off.
     is_first_scanline_after_lcd_on: bool, // for the LCD on/off quirk. If first scanline since the ppu is on, the cycle is shorter.
+    stat_interrupt_line: bool,
 }
 
 impl<T: Mbc> Ppu<T> {
@@ -103,6 +105,7 @@ impl<T: Mbc> Ppu<T> {
             current_obj_height: 0,
             lcd_was_enabled: false,
             is_first_scanline_after_lcd_on: false,
+            stat_interrupt_line: false,
         }
     }
 
@@ -653,10 +656,12 @@ impl<T: Mbc> Ppu<T> {
         self.update_ppu_mode(PpuMode::HBlank);
 
         self.lcd_was_enabled = false;
+        self.stat_interrupt_line = false;
     }
 
     pub fn tick(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         self.read_lcd_status();
+        self.check_lyc_equals_ly();
 
         if !self.read_lcdc().is_ppu_enabled() {
             self.reset_when_ppu_disabled();
@@ -681,6 +686,8 @@ impl<T: Mbc> Ppu<T> {
             PpuMode::VBlank => self.mode_vblank(),
         };
 
+        self.evaluate_stat_interrupt();
+
         was_updated
     }
 
@@ -695,9 +702,9 @@ impl<T: Mbc> Ppu<T> {
         self.lcd_status.set_lyc_equals_ly(lyc_match);
         self.write_stat_to_mmu();
         
-        if self.lcd_status.get_lyc_equals_ly() {
-            self.bus.write().unwrap().interrupts_request(Interrupt::LcdStat);
-        }
+        // if self.lcd_status.get_lyc_equals_ly() {
+        //     self.bus.write().unwrap().interrupts_request(Interrupt::LcdStat);
+        // }
     }
 
     fn update_ppu_mode(&mut self, mode: PpuMode) {
@@ -705,9 +712,24 @@ impl<T: Mbc> Ppu<T> {
         self.write_stat_to_mmu();
     }
 
+    fn evaluate_stat_interrupt(&mut self) {
+        let current_line = self.lcd_status.stat_interrupt_line();
+
+        if !self.stat_interrupt_line && current_line {
+            self.bus.write().unwrap().interrupts_request(Interrupt::LcdStat);
+        }
+
+        self.stat_interrupt_line = current_line;
+    }
+
+
     fn read_lcd_status(&mut self) {
-        let bus = self.bus.read().unwrap();
-        self.lcd_status.update_from_byte(bus.read_byte(STAT_ADDR));
+        let stat_byte = {
+            let bus = self.bus.read().unwrap();
+            bus.read_byte(STAT_ADDR)
+        };
+
+        self.lcd_status.update_from_byte(stat_byte);
     }
 
     fn read_scy(&self) -> u8 {
@@ -744,11 +766,11 @@ impl<T: Mbc> Ppu<T> {
 
     fn write_ly_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(LY_ADDR, self.ly);
+        bus.set_ly_from_ppu(self.ly);
     }
 
     fn write_stat_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(STAT_ADDR, self.lcd_status.struct_to_byte());
+        bus.set_stat_byte_from_ppu(self.lcd_status.struct_to_byte());
     }
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -629,13 +629,7 @@ impl<T: Mbc> Ppu<T> {
 
     pub fn write_data_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(LCD_CONTROL_ADDR, self.lcd_control.to_byte());
         bus.write_byte(STAT_ADDR, self.lcd_status.struct_to_byte());
-        bus.write_byte(SCY_ADDR, self.scy);
-        bus.write_byte(SCX_ADDR, self.scx);
-        bus.write_byte(LYC_ADDR, self.lyc);
-        bus.write_byte(WY_ADDR, self.wy);
-        bus.write_byte(WX_ADDR, self.wx);
         bus.write_byte(LY_ADDR, self.ly);
     }
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -576,7 +576,7 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
-    pub fn tick(&mut self, cycles: u32,  image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
+    pub fn tick(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
         self.fetch_data_from_mmu();
 
         if !self.lcd_control.is_ppu_enabled() {
@@ -586,7 +586,7 @@ impl<T: Mbc> Ppu<T> {
             return false;
         }
 
-        self.dots += cycles;
+        self.dots += 1;
 
         if self.wy == self.ly { self.wy_equal_ly_condition_met = true; }
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -524,6 +524,11 @@ impl<T: Mbc> Ppu<T> {
             }
 
             self.ly += 1;
+
+            let mut bus = self.bus.write().unwrap();
+            bus.write_byte(LY_ADDR, self.ly);
+            drop(bus);
+
             self.check_lyc_equals_ly();
 
             // reset for newline
@@ -552,11 +557,20 @@ impl<T: Mbc> Ppu<T> {
     fn mode_vblank(&mut self) -> bool {
         if self.dots >= SCANLINE_DOTS {
             self.dots -= SCANLINE_DOTS;
+
             self.ly += 1;
+            let mut bus = self.bus.write().unwrap();
+            bus.write_byte(LY_ADDR, self.ly);
+            drop(bus);
+
             self.check_lyc_equals_ly();
 
             if self.ly >= WIN_SIZE_Y as u8 + VBLANK_SIZE as u8 {
                 self.ly = 0;
+                let mut bus = self.bus.write().unwrap();
+                bus.write_byte(LY_ADDR, self.ly);
+                drop(bus);
+
                 self.check_lyc_equals_ly();
 
                 self.wly = 0;
@@ -581,6 +595,10 @@ impl<T: Mbc> Ppu<T> {
 
         if !self.lcd_control.is_ppu_enabled() {
             self.ly = 0;
+            let mut bus = self.bus.write().unwrap();
+            bus.write_byte(LY_ADDR, self.ly);
+            drop(bus);
+
             self.dots = 0;
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
             return false;
@@ -630,6 +648,7 @@ impl<T: Mbc> Ppu<T> {
     pub fn write_data_to_mmu(&mut self) {
         let mut bus = self.bus.write().unwrap();
         bus.write_byte(STAT_ADDR, self.lcd_status.struct_to_byte());
-        bus.write_byte(LY_ADDR, self.ly);
+        bus.write_byte(LYC_ADDR, self.lyc);
+        // bus.write_byte(LY_ADDR, self.ly);
     }
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -362,8 +362,7 @@ impl<T: Mbc> Ppu<T> {
         }
 
         if self.dots >= OAM_DOTS {
-            self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
-            self.write_stat_to_mmu();
+            self.update_ppu_mode(PpuMode::PixelTransfer);
         }
 
         false
@@ -539,8 +538,7 @@ impl<T: Mbc> Ppu<T> {
         }
 
         if self.x == 160 {
-            self.lcd_status.update_ppu_mode(PpuMode::HBlank);
-            self.write_stat_to_mmu();
+            self.update_ppu_mode(PpuMode::HBlank);
         }
 
         false
@@ -590,15 +588,13 @@ impl<T: Mbc> Ppu<T> {
             self.advance_to_next_scanline();
 
             if self.ly >= WIN_SIZE_Y as u8 {
-                self.lcd_status.update_ppu_mode(PpuMode::VBlank);
-                self.write_stat_to_mmu();
+                self.update_ppu_mode(PpuMode::VBlank);
 
                 self.bus.write().unwrap().interrupts_request(Interrupt::VBlank);
 
                 return true;
             } else {
-                self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
-                self.write_stat_to_mmu();
+                self.update_ppu_mode(PpuMode::OamSearch);
             }
         }
         false
@@ -619,8 +615,7 @@ impl<T: Mbc> Ppu<T> {
         self.reset_for_new_scanline();
         self.wy_equal_ly_condition_met = false;
 
-        self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
-        self.write_stat_to_mmu();
+        self.update_ppu_mode(PpuMode::OamSearch);
     }
 
     fn advance_vblank_scanline(&mut self) {
@@ -655,8 +650,7 @@ impl<T: Mbc> Ppu<T> {
         self.write_ly_to_mmu();
 
         self.dots = 0;
-        self.lcd_status.update_ppu_mode(PpuMode::HBlank);
-        self.write_stat_to_mmu();
+        self.update_ppu_mode(PpuMode::HBlank);
 
         self.lcd_was_enabled = false;
     }
@@ -706,7 +700,12 @@ impl<T: Mbc> Ppu<T> {
         }
     }
 
-    pub fn read_lcd_status(&mut self) {
+    fn update_ppu_mode(&mut self, mode: PpuMode) {
+        self.lcd_status.update_ppu_mode(mode);
+        self.write_stat_to_mmu();
+    }
+
+    fn read_lcd_status(&mut self) {
         let bus = self.bus.read().unwrap();
         self.lcd_status.update_from_byte(bus.read_byte(STAT_ADDR));
     }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -339,6 +339,7 @@ impl<T: Mbc> Ppu<T> {
             self.oam_search();
 
             self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
+            self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
         }
 
         false
@@ -506,6 +507,7 @@ impl<T: Mbc> Ppu<T> {
         if self.x == 160 {
             // self.render_sprites(image);
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
+            self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
         }
 
         false
@@ -524,10 +526,7 @@ impl<T: Mbc> Ppu<T> {
             }
 
             self.ly += 1;
-
-            let mut bus = self.bus.write().unwrap();
-            bus.write_byte(LY_ADDR, self.ly);
-            drop(bus);
+            self.write_ly_to_mmu(self.ly);
 
             self.check_lyc_equals_ly();
 
@@ -543,12 +542,14 @@ impl<T: Mbc> Ppu<T> {
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);
+                self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
 
                 self.bus.write().unwrap().interrupts_request(Interrupt::VBlank);
 
                 return true;
             } else {
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
+                self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
             }
         }
         false
@@ -559,18 +560,14 @@ impl<T: Mbc> Ppu<T> {
             self.dots -= SCANLINE_DOTS;
 
             self.ly += 1;
-            let mut bus = self.bus.write().unwrap();
-            bus.write_byte(LY_ADDR, self.ly);
-            drop(bus);
+            self.write_ly_to_mmu(self.ly);
 
             self.check_lyc_equals_ly();
 
             if self.ly >= WIN_SIZE_Y as u8 + VBLANK_SIZE as u8 {
                 self.ly = 0;
-                let mut bus = self.bus.write().unwrap();
-                bus.write_byte(LY_ADDR, self.ly);
-                drop(bus);
-
+                self.write_ly_to_mmu(self.ly);
+               
                 self.check_lyc_equals_ly();
 
                 self.wly = 0;
@@ -585,6 +582,7 @@ impl<T: Mbc> Ppu<T> {
                 self.wy_equal_ly_condition_met = false;
 
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);
+                self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
             }
         }
         false
@@ -595,12 +593,11 @@ impl<T: Mbc> Ppu<T> {
 
         if !self.lcd_control.is_ppu_enabled() {
             self.ly = 0;
-            let mut bus = self.bus.write().unwrap();
-            bus.write_byte(LY_ADDR, self.ly);
-            drop(bus);
+            self.write_ly_to_mmu(self.ly);
 
             self.dots = 0;
             self.lcd_status.update_ppu_mode(PpuMode::HBlank);
+            self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
             return false;
         }
 
@@ -615,7 +612,6 @@ impl<T: Mbc> Ppu<T> {
             PpuMode::VBlank => self.mode_vblank(),
         };
 
-        self.write_data_to_mmu();
         was_updated
     }
 
@@ -628,6 +624,7 @@ impl<T: Mbc> Ppu<T> {
         */
         let lyc_match = self.ly == self.lyc;
         self.lcd_status.set_lyc_equals_ly(lyc_match);
+        self.write_stat_to_mmu(self.lcd_status.struct_to_byte());
         
         if lyc_match && self.lcd_status.get_lyc_equals_ly() {
             self.bus.write().unwrap().interrupts_request(Interrupt::LcdStat);
@@ -645,10 +642,14 @@ impl<T: Mbc> Ppu<T> {
         self.wx = bus.read_byte(WX_ADDR);
     }
 
-    pub fn write_data_to_mmu(&mut self) {
+
+    fn write_ly_to_mmu(&mut self, ly: u8) {
         let mut bus = self.bus.write().unwrap();
-        bus.write_byte(STAT_ADDR, self.lcd_status.struct_to_byte());
-        bus.write_byte(LYC_ADDR, self.lyc);
-        // bus.write_byte(LY_ADDR, self.ly);
+        bus.write_byte(LY_ADDR, ly);
+    }
+
+    fn write_stat_to_mmu(&mut self, stat: u8) {
+        let mut bus = self.bus.write().unwrap();
+        bus.write_byte(STAT_ADDR, stat);
     }
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -596,7 +596,7 @@ impl<T: Mbc> Ppu<T> {
     }
 
     pub fn tick(&mut self, image: &mut Arc<Mutex<Vec<u8>>>) -> bool {
-        self.fetch_data_from_mmu();
+        self.read_lcd_status();
 
         if !self.read_lcdc().is_ppu_enabled() {
             self.ly = 0;
@@ -640,7 +640,7 @@ impl<T: Mbc> Ppu<T> {
         }
     }
 
-    pub fn fetch_data_from_mmu(&mut self) {
+    pub fn read_lcd_status(&mut self) {
         let bus = self.bus.read().unwrap();
         self.lcd_status.update_from_byte(bus.read_byte(STAT_ADDR));
     }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -69,6 +69,9 @@ pub struct Ppu<T: Mbc> {
     fetching_sprite: bool, // pixel fetcher and pixel shifter need to be paused while oam fetcher is called
     current_sprite_to_fetch: Option<usize>,
     wy_equal_ly_condition_met: bool,
+    oam_scan_index: u8, // index scanned sprites in OAM Search
+    visible_sprites_count: u8,
+    current_obj_height: u8,
 }
 
 impl<T: Mbc> Ppu<T> {
@@ -92,6 +95,9 @@ impl<T: Mbc> Ppu<T> {
             fetching_sprite: false,
             current_sprite_to_fetch: None,
             wy_equal_ly_condition_met: false,
+            oam_scan_index: 0,
+            visible_sprites_count: 0,
+            current_obj_height: 0,
         }
     }
 
@@ -322,10 +328,35 @@ impl<T: Mbc> Ppu<T> {
 
 
     fn mode_oam_search(&mut self) -> bool {
-        if self.dots >= OAM_DOTS {
+        if self.dots == 1 {
+            self.oam_scan_index = 0;
+            self.visible_sprites_count = 0;
             self.visible_sprites = [None; 10];
-            self.oam_search();
+            self.current_obj_height = if self.read_lcdc().is_obj_size_8x16() {
+                16
+            } else {
+                8
+            };
+        }
 
+        if self.dots % 2 == 0 && self.oam_scan_index < 40 {
+            let mmu = self.bus.read().unwrap();
+            let oam = mmu.get_oam();
+
+            let mut sprite = oam.sprites[self.oam_scan_index as usize];
+
+            if sprite.is_visible(self.ly, self.current_obj_height)
+                && self.visible_sprites_count < 10 {
+                sprite.oam_index = self.oam_scan_index;
+
+                self.visible_sprites[self.visible_sprites_count as usize] = Some(sprite);
+
+                self.visible_sprites_count += 1;
+            }
+            self.oam_scan_index += 1;
+        }
+
+        if self.dots >= OAM_DOTS {
             self.lcd_status.update_ppu_mode(PpuMode::PixelTransfer);
             self.write_stat_to_mmu();
         }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -76,6 +76,7 @@ pub struct Ppu<T: Mbc> {
     lcd_was_enabled: bool, // for the LCD on/off quirk. We need to detect if the ppu is on for the first time since it was off.
     is_first_scanline_after_lcd_on: bool, // for the LCD on/off quirk. If first scanline since the ppu is on, the cycle is shorter.
     stat_interrupt_line: bool,
+    stall_dots: u8, // to handle the sprite penalty in mode pixel transfer
 }
 
 impl<T: Mbc> Ppu<T> {
@@ -106,6 +107,7 @@ impl<T: Mbc> Ppu<T> {
             lcd_was_enabled: false,
             is_first_scanline_after_lcd_on: false,
             stat_interrupt_line: false,
+            stall_dots: 0,
         }
     }
 
@@ -477,9 +479,13 @@ impl<T: Mbc> Ppu<T> {
                         self.x,
                     );
 
-
                     if !self.fetching_sprite {
                         self.visible_sprites[index] = None;
+
+                        let remaining_pixels = self.bg_fifo.len() as u8;
+                        if remaining_pixels < 6 {
+                            self.stall_dots = 6 - remaining_pixels;
+                        }
                     }
                 }
             };
@@ -533,10 +539,14 @@ impl<T: Mbc> Ppu<T> {
             self.step_oam_fetcher();
 
             if !self.fetching_sprite {
-                self.step_pixel_fetcher(use_window);
-                let mut frame = image.lock().unwrap();
-                self.handle_window_switch(use_window);
-                self.push_pixel_to_screen(&mut frame, use_window);
+                if self.stall_dots > 0 {
+                    self.stall_dots -= 1;
+                } else {
+                    self.step_pixel_fetcher(use_window);
+                    let mut frame = image.lock().unwrap();
+                    self.handle_window_switch(use_window);
+                    self.push_pixel_to_screen(&mut frame, use_window);
+                }
             }
         }
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -367,6 +367,12 @@ impl<T: Mbc> Ppu<T> {
         }
 
         if self.dots >= OAM_DOTS {
+            let sorted = self.sort_sprites_by_x();
+            self.visible_sprites = [None; 10];
+            for (i, sprite) in sorted.into_iter().enumerate() {
+                self.visible_sprites[i] = Some(sprite);
+            }
+
             self.update_ppu_mode(PpuMode::PixelTransfer);
         }
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -541,6 +541,15 @@ impl<T: Mbc> Ppu<T> {
         false
     }
 
+    fn reset_hvblank(&mut self) {
+        self.x = 0;
+        self.bg_fifo.clear();
+        self.obj_piso.reset();
+        self.pixel_fetcher.reset_for_scanline();       
+        self.pixels_to_discard = self.read_scx() % 8;
+        self.use_window = false;
+        self.is_wx_glitch_happened = false;
+    }
 
     fn mode_hblank(&mut self) -> bool {
         // End of scanline -> next one after 456 dots
@@ -562,18 +571,7 @@ impl<T: Mbc> Ppu<T> {
 
             self.check_lyc_equals_ly();
 
-            // reset for newline
-            // TODO proper reset function
-            self.x = 0;
-            self.bg_fifo.clear();
-            self.obj_piso.reset();
-            self.pixel_fetcher.reset_for_scanline();
-
-            let scx = self.read_scx();
-
-            self.pixels_to_discard = scx % 8;
-            self.use_window = false;
-            self.is_wx_glitch_happened = false;
+            self.reset_hvblank();
 
             if self.ly >= WIN_SIZE_Y as u8 {
                 self.lcd_status.update_ppu_mode(PpuMode::VBlank);
@@ -606,17 +604,9 @@ impl<T: Mbc> Ppu<T> {
                 self.check_lyc_equals_ly();
 
                 self.wly = 0;
-                // TODO proper reset function
-                self.x = 0;
-                self.bg_fifo.clear();
-                self.obj_piso.reset();
-                self.pixel_fetcher.reset_for_scanline();
 
-                let scx = self.read_scx();
+                self.reset_hvblank();
 
-                self.pixels_to_discard = scx % 8;
-                self.use_window = false;
-                self.is_wx_glitch_happened = false;
                 self.wy_equal_ly_condition_met = false;
 
                 self.lcd_status.update_ppu_mode(PpuMode::OamSearch);

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -12,7 +12,6 @@ mod oam_fetcher;
 
 use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
-use std::thread::current;
 
 use crate::mmu::mbc::Mbc;
 use crate::mmu::MemoryRegion;
@@ -339,7 +338,7 @@ impl<T: Mbc> Ppu<T> {
 
     fn mode_oam_search(&mut self) -> bool {
         if self.dots == 1 {
-            self.bus.write().unwrap().update_accessed_oam_row(0);
+            self.bus.write().unwrap().set_accessed_oam_row(0);
             self.oam_scan_index = 0;
             self.visible_sprites_count = 0;
             self.visible_sprites = [None; 10];
@@ -381,7 +380,7 @@ impl<T: Mbc> Ppu<T> {
             }
 
             self.update_ppu_mode(PpuMode::PixelTransfer);
-            self.bus.write().unwrap().update_accessed_oam_row(0xFF);
+            self.bus.write().unwrap().set_accessed_oam_row(0xFF);
         }
 
         false

--- a/src/ppu/lcd_control.rs
+++ b/src/ppu/lcd_control.rs
@@ -106,6 +106,13 @@ impl LcdControl {
     pub fn is_bg_window_enabled(&self) -> bool {
         self.bg_window_enable
     }
+    
+    pub fn from_byte(byte: u8) -> Self {
+        let mut lcdc = Self::default();
+        lcdc.update_from_byte(byte);
+
+        lcdc
+    }
 
     pub fn update_from_byte(&mut self, value: u8) {
         self.ppu_enable = value & PPU_ENABLE_MASK != 0;

--- a/src/ppu/lcd_status.rs
+++ b/src/ppu/lcd_status.rs
@@ -79,6 +79,9 @@ impl LcdStatus {
         // Bits 1-0: PPU mode
         stat |= self.ppu_mode as u8;
 
+        // Always at 1
+        stat |= 0b1000_0000;
+
         stat
     }
 
@@ -89,5 +92,23 @@ impl LcdStatus {
         self.mode_0_int_select = (value & 0b0000_1000) != 0;
 
         // Bits 2, 1, 0 are read-only
+    }
+
+    pub fn stat_interrupt_line(&self) -> bool {
+        let mut line = false;
+        if self.lyc_int_select && self.lyc_equals_ly {
+            line = true;
+        }
+        if self.mode_2_int_select && self.ppu_mode == PpuMode::OamSearch {
+            line = true;
+        }
+        if self.mode_1_int_select && self.ppu_mode == PpuMode::VBlank {
+            line = true;
+        }
+        if self.mode_0_int_select && self.ppu_mode == PpuMode::HBlank {
+            line = true;
+        }
+
+        line
     }
 }


### PR DESCRIPTION
# Cycle Accurate PPU and other changes

## Feat
- write and read of addresses in the ppu are done at the specific moment we need to instead of doing it once every tick.
- All cycles tick the exact time they need to. For example, the OAM Search takes 2 dots for every sprites, and the pixel transfer apply the timing penalties when fetching sprites.
- Ly=153 quirk implemented (weird hardware behavior where LY is reset a little before the end of the scanline)
- LCD on/off quirk implemented (weird hardware behavior, the first scanline after the LCD is on is shorter.)
- OAM bug handling (hardware bug which corrupts pixels in some cases)
- OAM DMA handling (Direct Memory Access, DMA transfers copy data from ROM or RAM to the OAM in a timely manner. It lasts 160 ticks).

## Fix
- change ime state into t-cycle instead of m-cycle in CPU
Just a small fix of timing.
- remove useless write that we were doing in the PPU even if the ppu is not supposed to write to these addresses, except for the lcd status because I'm not sure how to handle that.
- sort sprites by x in pixel transfer mode. I thought it was only for CGB but that's actually the opposite.

## Refactor
- change signature of ppu.tick() since the cycle is always 1
- clean reset when hblank and vblank modes
- update_ppu_mode() function

And some more little refactoring/fixes.
I wanted to do way more but this is already huge and we need to move on to more important aspects of the project.